### PR TITLE
fix: Reset global mutable state at program start (#26)

### DIFF
--- a/src/eval.ml
+++ b/src/eval.ml
@@ -300,6 +300,7 @@ let rec eval_toplevel (env : env) (expr : expr) : env =
       env
 
 let eval_program exprs =
+  imported_libraries := StringMap.empty;
   try
     let env = List.fold_left eval_toplevel StringMap.empty exprs in
     match StringMap.find_opt "main" env with

--- a/src/infer.ml
+++ b/src/infer.ml
@@ -18,6 +18,7 @@ let compose s1 s2 =
   List.map (fun (v, t) -> (v, apply s1 t)) s2 @ s1
 
 let counter = ref 0
+let reset_counter () = counter := 0
 let fresh_var () =
   let v = Printf.sprintf "a%d" !counter in
   incr counter; TVar v

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -360,6 +360,7 @@ let string_of_typ t =
   in aux t
 
 let parse_and_infer ?(show_types=true) input =
+  Infer.reset_counter ();
   let exprs = parse input in
   let env = Infer.add_operators_to_env Types.StringMap.empty in
   let rec infer_toplevel env = function


### PR DESCRIPTION
## Summary
- Reset `imported_libraries` cache at start of `eval_program`
- Added `Infer.reset_counter()` and call it at start of `parse_and_infer`
- Prevents state leaking between runs in same process

Closes #26