### PR TITLE
Add date/time standard library functions

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,7 @@
 (library
  (name churing_lib)
  (modules parser eval ast types infer)
+ (libraries unix)
  (wrapped false)
  (flags (:standard -w -27)))
 

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -250,6 +250,43 @@ let create_string_functions env =
       | VBool false -> VString "false"
       | v -> VString (string_of_value v)))
 
+(* Date/Time primitives *)
+let create_time_functions env =
+  let expect_int name = function
+    | VInt n -> n
+    | _ -> raise (RuntimeError (name ^ ": expected int"))
+  in
+  let tm_of_ts ts = Unix.localtime (float_of_int ts) in
+  env
+  |> StringMap.add "now" (VPrim (fun _ -> VInt (int_of_float (Unix.time ()))))
+  |> StringMap.add "timeMs" (VPrim (fun _ -> VInt (int_of_float (Unix.gettimeofday () *. 1000.0))))
+  |> StringMap.add "year" (VPrim (fun args ->
+      let tm = tm_of_ts (expect_int "year" (List.hd args)) in
+      VInt (tm.Unix.tm_year + 1900)))
+  |> StringMap.add "month" (VPrim (fun args ->
+      let tm = tm_of_ts (expect_int "month" (List.hd args)) in
+      VInt (tm.Unix.tm_mon + 1)))
+  |> StringMap.add "day" (VPrim (fun args ->
+      let tm = tm_of_ts (expect_int "day" (List.hd args)) in
+      VInt tm.Unix.tm_mday))
+  |> StringMap.add "hour" (VPrim (fun args ->
+      let tm = tm_of_ts (expect_int "hour" (List.hd args)) in
+      VInt tm.Unix.tm_hour))
+  |> StringMap.add "minute" (VPrim (fun args ->
+      let tm = tm_of_ts (expect_int "minute" (List.hd args)) in
+      VInt tm.Unix.tm_min))
+  |> StringMap.add "second" (VPrim (fun args ->
+      let tm = tm_of_ts (expect_int "second" (List.hd args)) in
+      VInt tm.Unix.tm_sec))
+  |> StringMap.add "diffTime" (VPrim (fun args ->
+      let a = expect_int "diffTime" (List.hd args) in
+      VPrim (fun args ->
+        let b = expect_int "diffTime" (List.hd args) in
+        VInt (a - b))))
+  |> StringMap.add "dayOfWeek" (VPrim (fun args ->
+      let tm = tm_of_ts (expect_int "dayOfWeek" (List.hd args)) in
+      VInt tm.Unix.tm_wday))
+
 (* List primitives *)
 (* Forward reference for eval — set by eval_with_imports at startup *)
 let eval_ref : (env -> expr -> env * value) ref = ref (fun _ _ -> failwith "eval not initialized")
@@ -395,6 +432,11 @@ let rec eval_with_imports env expr =
       )
       else if lib_name = "list" then (
         let final_env = create_list_functions env in
+        imported_libraries := StringMap.add lib_name true !imported_libraries;
+        (final_env, VInt 0)
+      )
+      else if lib_name = "time" then (
+        let final_env = create_time_functions env in
         imported_libraries := StringMap.add lib_name true !imported_libraries;
         (final_env, VInt 0)
       )

--- a/src/infer.ml
+++ b/src/infer.ml
@@ -145,6 +145,20 @@ let add_operators_to_env env =
   let a = fresh_var () in
   let env = StringMap.add "toString" (mono (TFun (a, t_str))) env in
 
+  (* Date/Time functions *)
+  let t_dummy = fresh_var () in
+  let env = StringMap.add "now" (mono (TFun (t_dummy, TInt))) env in
+  let t_dummy2 = fresh_var () in
+  let env = StringMap.add "timeMs" (mono (TFun (t_dummy2, TInt))) env in
+  let env = StringMap.add "year" (mono (TFun (TInt, TInt))) env in
+  let env = StringMap.add "month" (mono (TFun (TInt, TInt))) env in
+  let env = StringMap.add "day" (mono (TFun (TInt, TInt))) env in
+  let env = StringMap.add "hour" (mono (TFun (TInt, TInt))) env in
+  let env = StringMap.add "minute" (mono (TFun (TInt, TInt))) env in
+  let env = StringMap.add "second" (mono (TFun (TInt, TInt))) env in
+  let env = StringMap.add "dayOfWeek" (mono (TFun (TInt, TInt))) env in
+  let env = StringMap.add "diffTime" (mono (TFun (TInt, TFun (TInt, TInt)))) env in
+
   (* List operations — polymorphic via fresh vars *)
   let a1 = fresh_var () in
   let env = StringMap.add "cons" (mono (TFun (a1, TFun (TList a1, TList a1)))) env in

--- a/src/test/20_datetime.ch
+++ b/src/test/20_datetime.ch
@@ -1,0 +1,28 @@
+# Test date/time standard library functions
+import "time"
+
+~(
+    # now returns a positive timestamp
+    @ts (now 0)
+    assert (not (eq ts 0))
+
+    # year/month/day extract components
+    @y (year ts)
+    assert (not (eq y 0))
+
+    # diffTime
+    assert (eq (diffTime 100 50) 50)
+    assert (eq (diffTime 50 100) 0 - 50)
+
+    # dayOfWeek returns 0-6
+    @dow (dayOfWeek ts)
+    assert (not (eq dow 0 - 1))
+
+    # extractors on a known timestamp (Unix epoch = Jan 1 1970 00:00:00 UTC)
+    # Note: these depend on timezone, so we just test they return integers
+    @h (hour 0)
+    @m (minute 0)
+    @s (second 0)
+    assert (eq m 0)
+    assert (eq s 0)
+)


### PR DESCRIPTION
## Summary
- Add `import "time"` with: `now`, `timeMs`, `year`, `month`, `day`, `hour`, `minute`, `second`, `dayOfWeek`, `diffTime`
- Zero-arg functions (`now`, `timeMs`) take a dummy argument per lambda calculus convention: `now 0`
- Extractors are pure functions on Unix timestamps (integers)
- Added `unix` library dependency to dune config

Closes #14

## Test plan
- [x] All 42 OCaml unit tests pass
- [x] All 20 integration tests pass (new: `20_datetime.ch`)