### PR TITLE
Add pattern matching with two approaches

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -18,7 +18,17 @@ type expr =
   | Print of expr
   | Assert of expr
   | List of expr list
+  | Match of expr * (pattern * expr) list
   | Import of string
+
+and pattern =
+  | PInt of int
+  | PStr of string
+  | PBool of bool
+  | PVar of string
+  | PWild
+  | PList of pattern list
+  | PCons of pattern * pattern  (* head :: tail destructuring *)
 
 let rec string_of_typ = function
   | Types.TInt -> "Int"
@@ -53,7 +63,20 @@ let rec string_of_expr = function
   | Print e -> "print " ^ string_of_expr e
   | Assert e -> "assert " ^ string_of_expr e
   | List es -> "[" ^ String.concat ", " (List.map string_of_expr es) ^ "]"
+  | Match (e, arms) ->
+      "match " ^ string_of_expr e ^ " " ^
+      String.concat " " (List.map (fun (p, body) ->
+        "| " ^ string_of_pattern p ^ " -> " ^ string_of_expr body) arms)
   | Import lib -> "import " ^ lib
+
+and string_of_pattern = function
+  | PInt n -> string_of_int n
+  | PStr s -> "\"" ^ s ^ "\""
+  | PBool b -> string_of_bool b
+  | PVar x -> x
+  | PWild -> "_"
+  | PList ps -> "[" ^ String.concat ", " (List.map string_of_pattern ps) ^ "]"
+  | PCons (h, t) -> string_of_pattern h ^ " :: " ^ string_of_pattern t
 
 let string_of_exprs exprs =
   String.concat "\n" (List.map string_of_expr exprs)

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -379,6 +379,23 @@ let create_list_functions env =
         VPrim (fun args ->
           let l = expect_list "foldr" (List.hd args) in
           List.fold_right (fun v acc -> apply_fn (apply_fn f v) acc) l init))))
+  (* Church-style eliminators: matchList value on_empty on_cons *)
+  |> StringMap.add "matchList" (VPrim (fun args ->
+      let l = List.hd args in
+      VPrim (fun args ->
+        let on_empty = List.hd args in
+        VPrim (fun args ->
+          let on_cons = List.hd args in
+          match l with
+          | VList [] | VNil -> apply_fn on_empty VNil
+          | VList (h :: t) -> apply_fn (apply_fn on_cons h) (VList t)
+          | _ -> raise (RuntimeError "matchList: expected list")))))
+  (* matchBool: matchBool cond on_true on_false — Scott-encoded boolean eliminator *)
+  |> StringMap.add "matchBool" (VPrim (fun args ->
+      match List.hd args with
+      | VBool true -> VPrim (fun args -> let t = List.hd args in VPrim (fun _ -> t))
+      | VBool false -> VPrim (fun _ -> VPrim (fun args -> List.hd args))
+      | _ -> raise (RuntimeError "matchBool: expected bool")))
 
 (* Helper for binary numeric operations with type coercion *)
 let eval_numeric_binop va vb int_op long_op float_op name =
@@ -407,6 +424,44 @@ let eval_div_values va vb =
   | VInt x, VFloat y -> check_zero_float y; VFloat (float_of_int x /. y)
   | VFloat x, VInt y -> check_zero_int y; VFloat (x /. float_of_int y)
   | _ -> raise (RuntimeError "Type error in div")
+
+(* Pattern matching — returns Some bindings or None *)
+let rec match_pattern (pat : Ast.pattern) (v : value) : (string * value) list option =
+  match pat, v with
+  | Ast.PWild, _ -> Some []
+  | Ast.PVar x, _ -> Some [(x, v)]
+  | Ast.PInt n, VInt m when n = m -> Some []
+  | Ast.PStr s, VString t when s = t -> Some []
+  | Ast.PBool b, VBool c when b = c -> Some []
+  | Ast.PList pats, VList vs ->
+      if List.length pats <> List.length vs then None
+      else
+        let rec zip ps vs acc =
+          match ps, vs with
+          | [], [] -> Some acc
+          | p :: ps', v :: vs' ->
+              (match match_pattern p v with
+               | Some binds -> zip ps' vs' (acc @ binds)
+               | None -> None)
+          | _ -> None
+        in
+        zip pats vs []
+  | Ast.PList [], VNil -> Some []
+  | Ast.PCons (hp, tp), VList (h :: t) ->
+      (match match_pattern hp h with
+       | Some hb ->
+           (match match_pattern tp (VList t) with
+            | Some tb -> Some (hb @ tb)
+            | None -> None)
+       | None -> None)
+  | Ast.PCons (hp, tp), VCons (h, t) ->
+      (match match_pattern hp h with
+       | Some hb ->
+           (match match_pattern tp t with
+            | Some tb -> Some (hb @ tb)
+            | None -> None)
+       | None -> None)
+  | _ -> None
 
 (* Define an eval_with_imports function to handle environment properly *)
 (* eval_with_imports and force are mutually recursive for tail call optimization *)
@@ -575,6 +630,19 @@ let rec eval_with_imports env expr =
            raise (AssertionFailure ("Assertion failed: " ^ Ast.string_of_expr e))
        | _ ->
            raise (AssertionFailure ("Assert requires a boolean, got: " ^ Ast.string_of_expr e)))
+  | Match (scrutinee, arms) ->
+      let (env', sv) = eval_with_imports env scrutinee in
+      let sv = force sv in
+      let rec try_arms = function
+        | [] -> raise (RuntimeError ("No matching pattern for: " ^ string_of_value sv))
+        | (pat, body) :: rest ->
+            (match match_pattern pat sv with
+             | Some bindings ->
+                 let env'' = List.fold_left (fun e (k, v) -> StringMap.add k v e) env' bindings in
+                 eval_with_imports env'' body
+             | None -> try_arms rest)
+      in
+      try_arms arms
 
 (* Trampoline: resolve VTailCall chains without growing the stack.
    force is tail-recursive, so OCaml optimizes it into a loop. *)

--- a/src/infer.ml
+++ b/src/infer.ml
@@ -195,6 +195,18 @@ let add_operators_to_env env =
   let b13 = fresh_var () in
   let env = StringMap.add "pair" (mono (TFun (a13, TFun (b13, TFun (TFun (a13, TFun (b13, a13)), a13))))) env in
   let env = StringMap.add "nil" (mono (TList (fresh_var ()))) env in
+
+  (* Church-style eliminators *)
+  let ml_a = fresh_var () in
+  let ml_b = fresh_var () in
+  (* matchList : [a] -> (unit -> b) -> (a -> [a] -> b) -> b *)
+  let env = StringMap.add "matchList" (mono (TFun (TList ml_a,
+    TFun (TFun (TList ml_a, ml_b),
+    TFun (TFun (ml_a, TFun (TList ml_a, ml_b)), ml_b))))) env in
+  let mb_a = fresh_var () in
+  let mb_b = fresh_var () in
+  (* matchBool : Bool -> a -> a -> a *)
+  let env = StringMap.add "matchBool" (mono (TFun (TBool, TFun (mb_a, TFun (mb_b, mb_a))))) env in
   env
 
 let rec infer env = function
@@ -294,5 +306,39 @@ let rec infer env = function
       let s1, t1 = infer env e in
       let s2 = unify (apply s1 t1) TBool in
       (compose s2 s1, TBool)
+  | Match (scrutinee, arms) ->
+      let s0, t_scrut = infer env scrutinee in
+      let result_tv = fresh_var () in
+      let s, t_result = List.fold_left (fun (s_acc, t_res) (pat, body) ->
+        let env' = apply_env s_acc env in
+        let s_pat, pat_bindings = infer_pattern pat (apply s_acc t_scrut) in
+        let env'' = List.fold_left (fun e (name, t) -> StringMap.add name (mono t) e) env' pat_bindings in
+        let s1, t_body = infer env'' body in
+        let s2 = unify (apply s1 t_res) t_body in
+        (compose s2 (compose s1 (compose s_pat s_acc)), apply s2 t_body)
+      ) (s0, result_tv) arms in
+      (s, t_result)
   | Import _ ->
       ([], TInt)
+
+and infer_pattern pat t_scrut : subst * (string * typ) list =
+  match pat with
+  | Ast.PWild -> ([], [])
+  | Ast.PVar x -> ([], [(x, t_scrut)])
+  | Ast.PInt _ -> (unify t_scrut TInt, [])
+  | Ast.PStr _ -> (unify t_scrut TString, [])
+  | Ast.PBool _ -> (unify t_scrut TBool, [])
+  | Ast.PList pats ->
+      let elem_tv = fresh_var () in
+      let s0 = unify t_scrut (TList elem_tv) in
+      let s, bindings = List.fold_left (fun (s_acc, binds) p ->
+        let s1, pb = infer_pattern p (apply s_acc elem_tv) in
+        (compose s1 s_acc, binds @ pb)
+      ) (s0, []) pats in
+      (s, bindings)
+  | Ast.PCons (hp, tp) ->
+      let elem_tv = fresh_var () in
+      let s0 = unify t_scrut (TList elem_tv) in
+      let s1, hb = infer_pattern hp (apply s0 elem_tv) in
+      let s2, tb = infer_pattern tp (apply (compose s1 s0) t_scrut) in
+      (compose s2 (compose s1 s0), hb @ tb)

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -24,6 +24,9 @@ type token =
   | Comma
   | LBracket
   | RBracket
+  | Pipe
+  | Arrow
+  | ColonColon
   | Newline
   | Import  (* New token for import keyword *)
   | Eof
@@ -78,10 +81,16 @@ let tokenize s =
       aux (i+1) line (col+1) ((Comma, line, col) :: acc)
     else if i + 1 < String.length s && s.[i] = '|' && s.[i+1] = '>' then
       aux (i+2) line (col+2) ((Lambda, line, col) :: acc)
+    else if s.[i] = '|' then
+      aux (i+1) line (col+1) ((Pipe, line, col) :: acc)
+    else if i + 1 < String.length s && s.[i] = ':' && s.[i+1] = ':' then
+      aux (i+2) line (col+2) ((ColonColon, line, col) :: acc)
     else if is_whitespace s.[i] then
       aux (i+1) line (col+1) acc
     else if s.[i] = '+' then
       aux (i+1) line (col+1) ((Plus, line, col) :: acc)
+    else if i + 1 < String.length s && s.[i] = '-' && s.[i+1] = '>' then
+      aux (i+2) line (col+2) ((Arrow, line, col) :: acc)
     else if s.[i] = '-' then
       aux (i+1) line (col+1) ((Minus, line, col) :: acc)
     else if s.[i] = '*' then
@@ -154,6 +163,43 @@ let tokenize s =
 let rec skip_newlines = function
   | (Newline, _, _) :: rest -> skip_newlines rest
   | tokens -> tokens
+
+(* Pattern parsing for match expressions *)
+let rec parse_pattern tokens =
+  let pat, rest = parse_pattern_atom tokens in
+  (* Check for :: (cons pattern) *)
+  match rest with
+  | (ColonColon, _, _) :: rest' ->
+      let tail_pat, rest'' = parse_pattern rest' in
+      (PCons (pat, tail_pat), rest'')
+  | _ -> (pat, rest)
+
+and parse_pattern_atom tokens =
+  match tokens with
+  | (Integer n, _, _) :: rest -> (PInt n, rest)
+  | (String s, _, _) :: rest -> (PStr s, rest)
+  | (Ident "__church_true", _, _) :: rest -> (PBool true, rest)
+  | (Ident "__church_false", _, _) :: rest -> (PBool false, rest)
+  | (Underscore, _, _) :: rest -> (PWild, rest)
+  | (Ident name, _, _) :: rest -> (PVar name, rest)
+  | (LBracket, _, _) :: rest ->
+      let rec parse_list_pats toks acc =
+        let toks = skip_newlines toks in
+        match toks with
+        | (RBracket, _, _) :: rest' -> (List.rev acc, rest')
+        | _ ->
+            let p, rest' = parse_pattern toks in
+            let rest' = skip_newlines rest' in
+            (match rest' with
+             | (Comma, _, _) :: rest'' -> parse_list_pats rest'' (p :: acc)
+             | (RBracket, _, _) :: rest'' -> (List.rev (p :: acc), rest'')
+             | (_, line, col) :: _ -> raise (ParseError ("Expected ',' or ']' in pattern", line, col))
+             | [] -> raise (ParseError ("Unterminated list pattern", 1, 1)))
+      in
+      let pats, rest' = parse_list_pats rest [] in
+      (PList pats, rest')
+  | (tok, line, col) :: _ -> raise (ParseError ("Invalid pattern", line, col))
+  | [] -> raise (ParseError ("Expected pattern", 1, 1))
 
 (* Define all parsing functions with proper mutual recursion *)
 let rec parse_expr tokens = parse_fun_def tokens
@@ -275,6 +321,25 @@ and parse_primary tokens =
   | (Integer n, _, _) :: rest -> (Int n, rest)
   | (Long n, _, _) :: rest -> (Lng n, rest)
   | (Float f, _, _) :: rest -> (Float f, rest)
+  | (Ident "match", _, _) :: rest ->
+      let scrutinee, rest' = parse_primary (skip_newlines rest) in
+      let rec parse_arms toks acc =
+        let toks = skip_newlines toks in
+        match toks with
+        | (Pipe, _, _) :: rest'' ->
+            let pat, rest''' = parse_pattern (skip_newlines rest'') in
+            let rest''' = skip_newlines rest''' in
+            (match rest''' with
+             | (Arrow, _, _) :: rest'''' ->
+                 let body, rest''''' = parse_expr (skip_newlines rest'''') in
+                 parse_arms rest''''' ((pat, body) :: acc)
+             | (_, line, col) :: _ -> raise (ParseError ("Expected '->' after pattern", line, col))
+             | [] -> raise (ParseError ("Expected '->' after pattern", 1, 1)))
+        | _ -> (List.rev acc, toks)
+      in
+      let arms, rest'' = parse_arms rest' [] in
+      if arms = [] then raise (ParseError ("match requires at least one arm", 1, 1));
+      (Match (scrutinee, arms), rest'')
   | (Ident "print", _, _) :: rest ->
       let arg, rest' = parse_expr (skip_newlines rest) in
       (Print arg, rest')

--- a/src/test/21_pattern_match.ch
+++ b/src/test/21_pattern_match.ch
@@ -1,0 +1,66 @@
+# Test pattern matching (Option A — match expression)
+import "list"
+
+~(
+    # Match on integers
+    @x 42
+    @r1 (match x
+        | 0 -> "zero"
+        | 42 -> "answer"
+        | _ -> "other")
+    assert (eq r1 "answer")
+
+    # Match on booleans
+    @b true
+    @r2 (match b
+        | true -> "yes"
+        | false -> "no")
+    assert (eq r2 "yes")
+
+    # Match on strings
+    @s "hello"
+    @r3 (match s
+        | "hello" -> 1
+        | "world" -> 2
+        | _ -> 0)
+    assert (eq r3 1)
+
+    # Match with variable binding
+    @y 99
+    @r4 (match y
+        | n -> n + 1)
+    assert (eq r4 100)
+
+    # Match on lists — empty
+    @r5 (match []
+        | [] -> "empty"
+        | _ -> "nonempty")
+    assert (eq r5 "empty")
+
+    # Match on lists — exact pattern
+    @nums [1, 2, 3]
+    @r6 (match nums
+        | [1, 2, 3] -> "exact"
+        | _ -> "other")
+    assert (eq r6 "exact")
+
+    # Match with cons destructuring (head :: tail)
+    @r7 (match nums
+        | h :: t -> h)
+    assert (eq r7 1)
+
+    @r8 (match nums
+        | h :: t -> t)
+    assert (eq r8 [2, 3])
+
+    # Wildcard in patterns
+    @r9 (match [10, 20, 30]
+        | [_, second, _] -> second)
+    assert (eq r9 20)
+
+    # Nested match — factorial
+    ~fact n (match n
+        | 0 -> 1
+        | x -> x * fact (x - 1))
+    assert (eq (fact 5) 120)
+)

--- a/src/test/22_church_match.ch
+++ b/src/test/22_church_match.ch
@@ -1,0 +1,36 @@
+# Test Church-style eliminators (Option B — matching as function application)
+import "list"
+
+~(
+    # matchList: eliminates a list into empty/cons cases
+    @nums [1, 2, 3]
+
+    # Sum using matchList recursion
+    ~sumList l (matchList l
+        (|>_. 0)
+        (|>h. |>t. h + sumList t))
+    assert (eq (sumList nums) 6)
+    assert (eq (sumList []) 0)
+
+    # Length using matchList
+    ~listLen l (matchList l
+        (|>_. 0)
+        (|>_. |>t. 1 + listLen t))
+    assert (eq (listLen nums) 3)
+    assert (eq (listLen []) 0)
+
+    # matchBool: eliminates a boolean
+    @result (matchBool true "yes" "no")
+    assert (eq result "yes")
+
+    @result2 (matchBool false "yes" "no")
+    assert (eq result2 "no")
+
+    # Compose: filter using matchList + matchBool
+    ~myFilter f,l (matchList l
+        (|>_. [])
+        (|>h. |>t. matchBool (f h)
+            (cons h (myFilter f t))
+            (myFilter f t)))
+    assert (eq (myFilter (|>x. eq x 2) [1, 2, 3, 2]) [2, 2])
+)


### PR DESCRIPTION
## Summary

### Option A — `match` expression
Full pattern matching syntax with arms:
```
match expr
    | pattern -> body
    | _ -> default
```
Supported patterns: literals (`0`, `"hi"`, `true`), variables (`x`), wildcards (`_`), lists (`[x, y]`, `[]`), cons destructuring (`h :: t`).

### Option B — Church-style eliminators
- `matchList list on_empty on_cons` — Scott-encoded list eliminator
- `matchBool cond on_true on_false` — Scott-encoded boolean eliminator

Both compose naturally with lambdas for recursive processing.

Closes #6

## Test plan
- [x] All 42 OCaml unit tests pass
- [x] All 22 integration tests pass (new: `21_pattern_match.ch`, `22_church_match.ch`)