### PR TITLE
Add error handling with two approaches

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -19,6 +19,7 @@ type expr =
   | Assert of expr
   | List of expr list
   | Match of expr * (pattern * expr) list
+  | Try of expr * expr
   | Import of string
 
 and pattern =
@@ -67,6 +68,7 @@ let rec string_of_expr = function
       "match " ^ string_of_expr e ^ " " ^
       String.concat " " (List.map (fun (p, body) ->
         "| " ^ string_of_pattern p ^ " -> " ^ string_of_expr body) arms)
+  | Try (e, handler) -> "try " ^ string_of_expr e ^ " " ^ string_of_expr handler
   | Import lib -> "import " ^ lib
 
 and string_of_pattern = function

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -643,6 +643,23 @@ let rec eval_with_imports env expr =
              | None -> try_arms rest)
       in
       try_arms arms
+  | Try (expr, handler) ->
+      (try
+        let (env', v) = eval_with_imports env expr in
+        (env', force v)
+      with
+      | RuntimeError msg ->
+          let (_, hv) = eval_with_imports env handler in
+          let hv = force hv in
+          (env, apply_fn hv (VString msg))
+      | AssertionFailure msg ->
+          let (_, hv) = eval_with_imports env handler in
+          let hv = force hv in
+          (env, apply_fn hv (VString msg))
+      | Division_by_zero ->
+          let (_, hv) = eval_with_imports env handler in
+          let hv = force hv in
+          (env, apply_fn hv (VString "Division by zero")))
 
 (* Trampoline: resolve VTailCall chains without growing the stack.
    force is tail-recursive, so OCaml optimizes it into a loop. *)

--- a/src/infer.ml
+++ b/src/infer.ml
@@ -318,6 +318,12 @@ let rec infer env = function
         (compose s2 (compose s1 (compose s_pat s_acc)), apply s2 t_body)
       ) (s0, result_tv) arms in
       (s, t_result)
+  | Try (expr, handler) ->
+      let s1, t1 = infer env expr in
+      let s2, t2 = infer (apply_env s1 env) handler in
+      (* handler is String -> a, result must unify with expr type *)
+      let s3 = unify (apply s2 t2) (TFun (TString, apply s2 t1)) in
+      (compose s3 (compose s2 s1), apply s3 (apply s2 t1))
   | Import _ ->
       ([], TInt)
 

--- a/src/lib/result.ch
+++ b/src/lib/result.ch
@@ -1,0 +1,25 @@
+# Church-encoded Result type
+# Ok value  = |>onOk. |>onErr. onOk value
+# Err msg   = |>onOk. |>onErr. onErr msg
+
+# Constructors
+~ok v (|>onOk. |>onErr. onOk v)
+~err msg (|>onOk. |>onErr. onErr msg)
+
+# Eliminator: matchResult result onOk onErr
+~matchResult r,onOk,onErr (r onOk onErr)
+
+# Map over Ok value
+~mapResult f,r (r (|>v. ok (f v)) (|>e. err e))
+
+# Chain (flatMap/bind)
+~bindResult f,r (r f (|>e. err e))
+
+# Get value or default
+~unwrapOr default,r (r (|>v. v) (|>_. default))
+
+# Check if Ok
+~isOk r (r (|>_. true) (|>_. false))
+
+# Check if Err
+~isErr r (r (|>_. false) (|>_. true))

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -340,6 +340,10 @@ and parse_primary tokens =
       let arms, rest'' = parse_arms rest' [] in
       if arms = [] then raise (ParseError ("match requires at least one arm", 1, 1));
       (Match (scrutinee, arms), rest'')
+  | (Ident "try", _, _) :: rest ->
+      let expr, rest' = parse_primary (skip_newlines rest) in
+      let handler, rest'' = parse_primary (skip_newlines rest') in
+      (Try (expr, handler), rest'')
   | (Ident "print", _, _) :: rest ->
       let arg, rest' = parse_expr (skip_newlines rest) in
       (Print arg, rest')

--- a/src/test/23_try_catch.ch
+++ b/src/test/23_try_catch.ch
@@ -1,0 +1,31 @@
+# Test try/catch error handling (Option A — primitive)
+import "list"
+import "string"
+
+~(
+    # Catch division by zero
+    @r1 (try (10 / 0) (|>e. "caught"))
+    assert (eq r1 "caught")
+
+    # Catch runtime error
+    @r2 (try (head []) (|>e. "empty"))
+    assert (eq r2 "empty")
+
+    # No error — returns value normally
+    @r3 (try (10 + 5) (|>e. 0))
+    assert (eq r3 15)
+
+    # Error message is passed to handler
+    @r4 (try (head []) (|>msg. msg))
+    assert (startsWith r4 "head")
+
+    # Catch assertion failure
+    @r5 (try (assert false) (|>e. "assert caught"))
+    assert (eq r5 "assert caught")
+
+    # Nested try
+    @r6 (try
+        (try (1 / 0) (|>_. head []))
+        (|>e. "inner also failed"))
+    assert (eq r6 "inner also failed")
+)

--- a/src/test/24_result.ch
+++ b/src/test/24_result.ch
@@ -1,0 +1,40 @@
+# Test Church-encoded Result type (Option B — library)
+import "result"
+
+~(
+    # Create Ok and Err values
+    @success (ok 42)
+    @failure (err "something went wrong")
+
+    # matchResult — eliminate Result
+    assert (eq (matchResult success (|>v. v + 1) (|>e. 0)) 43)
+    assert (eq (matchResult failure (|>v. v) (|>e. e)) "something went wrong")
+
+    # isOk / isErr
+    assert (isOk success)
+    assert (not (isOk failure))
+    assert (isErr failure)
+    assert (not (isErr success))
+
+    # unwrapOr — get value or default
+    assert (eq (unwrapOr 0 success) 42)
+    assert (eq (unwrapOr 0 failure) 0)
+
+    # mapResult — transform Ok value
+    @doubled (mapResult (|>v. v * 2) success)
+    assert (eq (unwrapOr 0 doubled) 84)
+
+    # mapResult on Err passes through
+    @still_err (mapResult (|>v. v * 2) failure)
+    assert (isErr still_err)
+
+    # bindResult — chain computations
+    ~safeDivide x,y (
+        try (ok (div x y)) (|>e. err e)
+    )
+    @chained (bindResult (|>v. safeDivide v 2) (ok 10))
+    assert (eq (unwrapOr 0.0 chained) 5.0)
+
+    @chained_err (bindResult (|>v. safeDivide v 0) (ok 10))
+    assert (isErr chained_err)
+)


### PR DESCRIPTION
## Summary

### Option A — `try`/`catch` primitive
```
@result (try (1 / 0) (|>err. "caught: " + err))
```
Catches `RuntimeError`, `AssertionFailure`, and `Division_by_zero`. Handler receives error message as a string.

### Option B — Church-encoded Result type
```
import "result"
@success (ok 42)
@failure (err "oops")
assert (eq (unwrapOr 0 success) 42)
```
Pure lambda calculus Result encoding: `ok`/`err` constructors, `matchResult` eliminator, `mapResult`, `bindResult`, `unwrapOr`, `isOk`, `isErr`.

Both approaches compose: `try` catches runtime errors into values, `result` library provides pure Church-style error propagation.

Closes #8

## Test plan
- [x] All 42 OCaml unit tests pass
- [x] All 24 integration tests pass (new: `23_try_catch.ch`, `24_result.ch`)