### PR TITLE
Organize standard library into src/lib/ with hybrid import system

### DIFF
--- a/src/eval.ml
+++ b/src/eval.ml
@@ -470,59 +470,39 @@ let rec eval_with_imports env expr =
   | Import lib_name ->
       if StringMap.mem lib_name !imported_libraries then
         (env, VInt 0) (* Return unchanged env and dummy value *)
-      else if lib_name = "operators" then (
-        let final_env = create_church_booleans env in
-        imported_libraries := StringMap.add lib_name true !imported_libraries;
-        (final_env, VInt 0)
-      )
-      else if lib_name = "math" then (
-        let final_env = create_math_functions env in
-        imported_libraries := StringMap.add lib_name true !imported_libraries;
-        (final_env, VInt 0)
-      )
-      else if lib_name = "string" then (
-        let final_env = create_string_functions env in
-        imported_libraries := StringMap.add lib_name true !imported_libraries;
-        (final_env, VInt 0)
-      )
-      else if lib_name = "list" then (
-        let final_env = create_list_functions env in
-        imported_libraries := StringMap.add lib_name true !imported_libraries;
-        (final_env, VInt 0)
-      )
-      else if lib_name = "time" then (
-        let final_env = create_time_functions env in
-        imported_libraries := StringMap.add lib_name true !imported_libraries;
-        (final_env, VInt 0)
-      )
-      else (
-        (* Load the library *)
-        let lib_exprs = load_library lib_name in
-        (* Mark as imported to prevent cycles *)
-        imported_libraries := StringMap.add lib_name true !imported_libraries;
-
-        (* Process all expressions in the library *)
-        let new_env = List.fold_left
-          (fun acc_env expr ->
-            match expr with
-            | FunDef (name, args, body) ->
-                let func_val = VRecFun (name, args, body, acc_env) in
-                StringMap.add name func_val acc_env
-            | Let (name, value_expr) ->
-                (* Evaluate the value and add to environment *)
-                let (_, value) = eval_with_imports acc_env value_expr in
-                StringMap.add name (force value) acc_env
-            | _ ->
-                (* Evaluate other expressions but don't add to environment *)
-                let (_, v) = eval_with_imports acc_env expr in
-                ignore (force v);
-                acc_env
-          ) env lib_exprs
-        in
-
-        (* Return the updated environment and a dummy value *)
-        (new_env, VInt 0)
-      )
+      else
+      (* Native primitives for known libraries *)
+      let env_with_natives =
+        match lib_name with
+        | "operators" -> create_church_booleans env
+        | "math" -> create_math_functions env
+        | "string" -> create_string_functions env
+        | "list" -> create_list_functions env
+        | "time" -> create_time_functions env
+        | _ -> env
+      in
+      imported_libraries := StringMap.add lib_name true !imported_libraries;
+      (* Then load .ch file from src/lib/ if it exists *)
+      let final_env =
+        try
+          let lib_exprs = load_library lib_name in
+          List.fold_left
+            (fun acc_env expr ->
+              match expr with
+              | FunDef (name, args, body) ->
+                  let func_val = VRecFun (name, args, body, acc_env) in
+                  StringMap.add name func_val acc_env
+              | Let (name, value_expr) ->
+                  let (_, value) = eval_with_imports acc_env value_expr in
+                  StringMap.add name (force value) acc_env
+              | _ ->
+                  let (_, v) = eval_with_imports acc_env expr in
+                  ignore (force v);
+                  acc_env
+            ) env_with_natives lib_exprs
+        with RuntimeError _ -> env_with_natives
+      in
+      (final_env, VInt 0)
   | Int n -> (env, VInt n)
   | Lng n -> (env, VLong n)
   | Float f -> (env, VFloat f)

--- a/src/lib/list.ch
+++ b/src/lib/list.ch
@@ -1,0 +1,47 @@
+# List Library
+# Native primitives: nil, cons, head, tail, empty, len, nth, reverse,
+#   range, map, filter, foldl, foldr, matchList, matchBool
+
+# Sum all elements
+~sum l (foldl (|>acc. |>x. acc + x) 0 l)
+
+# Product of all elements
+~product l (foldl (|>acc. |>x. acc * x) 1 l)
+
+# Check if any element satisfies predicate
+~any f,l (foldl (|>acc. |>x. or acc (f x)) false l)
+
+# Check if all elements satisfy predicate
+~all f,l (foldl (|>acc. |>x. and acc (f x)) true l)
+
+# Take first n elements
+~take n,l (
+    matchList l
+        (|>_. [])
+        (|>h. |>t. eq n 0
+            (|>_. [])
+            (|>_. cons h (take (n - 1) t))
+        0))
+
+# Drop first n elements
+~drop n,l (
+    matchList l
+        (|>_. [])
+        (|>h. |>t. eq n 0
+            (|>_. cons h t)
+            (|>_. drop (n - 1) t)
+        0))
+
+# Zip two lists into a list of pairs (as 2-element lists)
+~zip a,b (
+    matchList a
+        (|>_. [])
+        (|>ha. |>ta. matchList b
+            (|>_. [])
+            (|>hb. |>tb. cons [ha, hb] (zip ta tb))))
+
+# Flatten a list of lists
+~flatten l (foldr (|>x. |>acc. foldl (|>a. |>e. cons e a) acc (reverse x)) [] l)
+
+# Append two lists
+~append a,b (foldr (|>x. |>acc. cons x acc) b a)

--- a/src/lib/math.ch
+++ b/src/lib/math.ch
@@ -1,0 +1,22 @@
+# Math Library
+# Native primitives: sqrt, sin, cos, tan, asin, acos, atan,
+#   floor, ceil, round, abs, pow, min, max
+
+# Constants (approximations)
+@pi 3.14159265358979323846
+@e 2.71828182845904523536
+
+# Additional helpers
+~square x (x * x)
+~cube x (x * x * x)
+~sign x (
+    eq x 0
+        (|>_. 0)
+        (|>_. eq (abs x) x
+            (|>_. 1)
+            (|>_. 0 - 1)
+        0)
+    0
+)
+~clamp lo,hi,x (min hi (max lo x))
+~lerp a,b,t (a + t * (b - a))

--- a/src/lib/operators.ch
+++ b/src/lib/operators.ch
@@ -1,28 +1,14 @@
-# Comprehensive Operators Library
-# This file defines all common operators including Church boolean functions
+# Operators Library
+# Native primitives: true, false, not, and, or, if
+# This file adds Churing-level helpers on top
 
-# Church-encoded boolean primitives - these should work fine
-~true x y x                    # Church true: Returns the first argument
-~false x y y                   # Church false: Returns the second argument
-
-# IF-THEN-ELSE construct using primitive if-then-else pattern
-~if x y z x y z                # Apply x to y and z directly
-
-# NOT function defined without referencing other functions
-~not x y z (x z y)             # Flip the arguments to negate
-
-# AND function defined without referencing other functions
-~and x y u v (x (y u v) v)     # If x then apply y, else return false (v)
-
-# OR function defined without referencing other functions
-~or x y u v (x u (y u v))      # If x then return true (u), else apply y
-
-# Basic arithmetic operators
-~add x y x + y                 # Addition operator
-~sub x y x - y                 # Subtraction operator
-~mul x y x * y                 # Multiplication operator
-~div x y x / y                 # Division operator
+# Basic arithmetic wrappers
+~add x,y x + y
+~sub x,y x - y
+~mul x,y x * y
 
 # Utility functions
-~identity x x                  # Identity function: Returns its argument unchanged
-~const x y x                   # Constant function (same as true)
+~identity x x
+~const x,y x
+~flip f,x,y (f y x)
+~compose f,g,x (f (g x))

--- a/src/lib/string.ch
+++ b/src/lib/string.ch
@@ -1,0 +1,28 @@
+# String Library
+# Native primitives: length, concat, substring, uppercase, lowercase,
+#   trim, charAt, indexOf, startsWith, endsWith, replace, toString
+
+# Check if string is empty
+~isEmpty s (eq (length s) 0)
+
+# Check if string contains a substring
+~contains s,sub (not (eq (indexOf s sub) (0 - 1)))
+
+# Repeat a string n times
+~repeat s,n (
+    eq n 0
+        (|>_. "")
+        (|>_. concat s (repeat s (n - 1)))
+    0
+)
+
+# Left pad string to length
+~padLeft target,pad,s (
+    eq (length s) target
+        (|>_. s)
+        (|>_. eq (length s) target
+            (|>_. s)
+            (|>_. padLeft target pad (concat pad s))
+        0)
+    0
+)

--- a/src/lib/time.ch
+++ b/src/lib/time.ch
@@ -1,0 +1,17 @@
+# Time Library
+# Native primitives: now, timeMs, year, month, day, hour, minute, second,
+#   dayOfWeek, diffTime
+
+# Check if a year is a leap year
+~isLeapYear y (
+    eq (y - (y / 4) * 4) 0
+        (|>_. eq (y - (y / 100) * 100) 0
+            (|>_. eq (y - (y / 400) * 400) 0
+                (|>_. true)
+                (|>_. false)
+            0)
+            (|>_. true)
+        0)
+        (|>_. false)
+    0
+)

--- a/src/test/25_lib_helpers.ch
+++ b/src/test/25_lib_helpers.ch
@@ -1,0 +1,38 @@
+# Test Churing-level helpers defined in library .ch files
+import "operators"
+import "math"
+import "string"
+import "list"
+
+~(
+    # operators.ch: identity, const, compose
+    assert (eq (identity 42) 42)
+    assert (eq (const 1 2) 1)
+    assert (eq (compose (|>x. x + 1) (|>x. x * 2) 5) 11)
+    assert (eq (flip sub 3 10) 7)
+
+    # math.ch: pi, square, cube, clamp, lerp
+    assert (eq (square 5) 25)
+    assert (eq (cube 3) 27)
+    assert (eq (clamp 0.0 10.0 15.0) 10.0)
+    assert (eq (clamp 0.0 10.0 5.0) 5.0)
+    assert (eq (lerp 0.0 10.0 0.5) 5.0)
+
+    # string.ch: isEmpty, contains, repeat
+    assert (isEmpty "")
+    assert (not (isEmpty "hi"))
+    assert (contains "hello world" "world")
+    assert (not (contains "hello" "xyz"))
+    assert (eq (repeat "ab" 3) "ababab")
+    assert (eq (repeat "x" 0) "")
+
+    # list.ch: sum, product, any, all, take, drop, append
+    assert (eq (sum [1, 2, 3, 4, 5]) 15)
+    assert (eq (product [1, 2, 3, 4]) 24)
+    assert (any (|>x. eq x 3) [1, 2, 3])
+    assert (not (any (|>x. eq x 9) [1, 2, 3]))
+    assert (all (|>x. not (eq x 0)) [1, 2, 3])
+    assert (eq (take 2 [1, 2, 3]) [1, 2])
+    assert (eq (drop 2 [1, 2, 3]) [3])
+    assert (eq (append [1, 2] [3, 4]) [1, 2, 3, 4])
+)


### PR DESCRIPTION
## Summary
- Refactor import system into a unified hybrid approach: inject native primitives first, then load `.ch` file from `src/lib/` to add Churing-level helpers
- Eliminates duplicated import handling code (5 separate if/else blocks → 1 unified flow)
- Every library now has a `.ch` file in `src/lib/`:
  - `operators.ch` — identity, const, flip, compose
  - `math.ch` — pi, e, square, cube, sign, clamp, lerp
  - `string.ch` — isEmpty, contains, repeat, padLeft
  - `list.ch` — sum, product, any, all, take, drop, zip, flatten, append
  - `time.ch` — isLeapYear
  - `church_list.ch`, `result.ch` — unchanged

## Test plan
- [x] All 42 OCaml unit tests pass
- [x] All 25 integration tests pass (new: `25_lib_helpers.ch` verifying library helpers)