### PR TITLE
Auto-load standard library prelude, no imports needed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,23 @@ A functional programming language named after Alonzo Church and Alan Turing, imp
 eq a b                       # Equality (returns boolean)
 assert expr                  # Assertion (fails with exit 1 if false)
 print expr                   # Output
-import "lib"                 # Import library
+match expr | pat -> body     # Pattern matching
+try expr (|>err. handler)    # Error handling
+[1, 2, 3]                   # List literal
+import "lib"                 # Import custom library (stdlib is auto-loaded)
 ```
+
+## Standard Library (auto-loaded)
+
+All standard library functions are available without imports:
+
+- **operators**: true, false, not, and, or, if, identity, const, flip, compose
+- **math**: sqrt, sin, cos, tan, asin, acos, atan, floor, ceil, round, abs, pow, min, max, pi, e, square, cube, clamp, lerp
+- **string**: length, concat, substring, uppercase, lowercase, trim, charAt, indexOf, startsWith, endsWith, replace, toString, isEmpty, contains, repeat
+- **list**: nil, cons, head, tail, empty, len, nth, reverse, range, map, filter, foldl, foldr, matchList, matchBool, sum, product, any, all, take, drop, zip, flatten, append
+- **time**: now, timeMs, year, month, day, hour, minute, second, dayOfWeek, diffTime, isLeapYear
+- **church_list**: church_nil, church_cons, church_head, church_sum, church_map, church_fold, church_length
+- **result**: ok, err, matchResult, mapResult, bindResult, unwrapOr, isOk, isErr
 
 ## Build & Test
 

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -691,10 +691,16 @@ let rec eval_toplevel (env : env) (expr : expr) : env =
       ignore (eval env expr);
       env
 
+let load_prelude () =
+  let stdlib = ["operators"; "math"; "string"; "list"; "time"; "church_list"; "result"] in
+  List.fold_left (fun env lib ->
+    fst (eval_with_imports env (Import lib))
+  ) StringMap.empty stdlib
+
 let eval_program exprs =
   imported_libraries := StringMap.empty;
   try
-    let env = List.fold_left eval_toplevel StringMap.empty exprs in
+    let env = List.fold_left eval_toplevel (load_prelude ()) exprs in
     match StringMap.find_opt "main" env with
     | Some (VFun ([], body, closure)) -> ignore (eval closure body)
     | _ -> ()

--- a/src/test/14_assert.ch
+++ b/src/test/14_assert.ch
@@ -1,5 +1,4 @@
 # Test the assert primitive itself
-import operators
 
 ~(
     assert true

--- a/src/test/15_math.ch
+++ b/src/test/15_math.ch
@@ -1,5 +1,4 @@
 # Test math standard library functions
-import "math"
 
 ~(
     # sqrt

--- a/src/test/16_string.ch
+++ b/src/test/16_string.ch
@@ -1,5 +1,4 @@
 # Test string standard library functions
-import "string"
 
 ~(
     # length

--- a/src/test/17_lists.ch
+++ b/src/test/17_lists.ch
@@ -1,5 +1,4 @@
 # Test native list literals and list operations (Approach B)
-import "list"
 
 @nums [1, 2, 3, 4, 5]
 @empty []

--- a/src/test/18_church_lists.ch
+++ b/src/test/18_church_lists.ch
@@ -1,5 +1,4 @@
 # Test Church-encoded lists (Approach A — pure lambda calculus)
-import "church_list"
 
 # Build a Church list: [1, 2, 3]
 @mylist (church_cons 1 (church_cons 2 (church_cons 3 church_nil)))

--- a/src/test/19_cons_cells.ch
+++ b/src/test/19_cons_cells.ch
@@ -1,5 +1,4 @@
 # Test cons cell operations (Approach C — Lisp-style)
-import "list"
 
 # Build list from cons/nil
 @mylist (cons 1 (cons 2 (cons 3 [])))

--- a/src/test/20_datetime.ch
+++ b/src/test/20_datetime.ch
@@ -1,5 +1,4 @@
 # Test date/time standard library functions
-import "time"
 
 ~(
     # now returns a positive timestamp

--- a/src/test/21_pattern_match.ch
+++ b/src/test/21_pattern_match.ch
@@ -1,5 +1,4 @@
 # Test pattern matching (Option A — match expression)
-import "list"
 
 ~(
     # Match on integers

--- a/src/test/22_church_match.ch
+++ b/src/test/22_church_match.ch
@@ -1,5 +1,4 @@
 # Test Church-style eliminators (Option B — matching as function application)
-import "list"
 
 ~(
     # matchList: eliminates a list into empty/cons cases

--- a/src/test/23_try_catch.ch
+++ b/src/test/23_try_catch.ch
@@ -1,6 +1,4 @@
 # Test try/catch error handling (Option A — primitive)
-import "list"
-import "string"
 
 ~(
     # Catch division by zero

--- a/src/test/24_result.ch
+++ b/src/test/24_result.ch
@@ -1,5 +1,4 @@
 # Test Church-encoded Result type (Option B — library)
-import "result"
 
 ~(
     # Create Ok and Err values

--- a/src/test/25_lib_helpers.ch
+++ b/src/test/25_lib_helpers.ch
@@ -1,8 +1,4 @@
 # Test Churing-level helpers defined in library .ch files
-import "operators"
-import "math"
-import "string"
-import "list"
 
 ~(
     # operators.ch: identity, const, compose


### PR DESCRIPTION
## Summary
- All standard library functions are automatically loaded at program startup
- No `import` statements needed for standard library — pure lambda calculus feel
- `import` still works for custom user libraries
- Removed all `import` lines from test files (12 files cleaned up)
- Updated CLAUDE.md with full standard library reference

Before:
```
import "list"
import "math"
~( print (map (|>x. sqrt x) [4.0, 9.0]) )
```

After:
```
~( print (map (|>x. sqrt x) [4.0, 9.0]) )
```

## Test plan
- [x] All unit tests pass
- [x] All 25 integration tests pass without any import statements