### PR TITLE
Add file I/O with two approaches

### DIFF
--- a/src/eval.ml
+++ b/src/eval.ml
@@ -287,6 +287,75 @@ let create_time_functions env =
       let tm = tm_of_ts (expect_int "dayOfWeek" (List.hd args)) in
       VInt tm.Unix.tm_wday))
 
+(* File I/O primitives *)
+let create_io_functions env =
+  let expect_string name = function
+    | VString s -> s
+    | _ -> raise (RuntimeError (name ^ ": expected string"))
+  in
+  env
+  |> StringMap.add "readFile" (VPrim (fun args ->
+      let path = expect_string "readFile" (List.hd args) in
+      try
+        let ic = open_in path in
+        let len = in_channel_length ic in
+        let content = really_input_string ic len in
+        close_in ic;
+        VString content
+      with Sys_error msg -> raise (RuntimeError ("readFile: " ^ msg))))
+  |> StringMap.add "writeFile" (VPrim (fun args ->
+      let path = expect_string "writeFile" (List.hd args) in
+      VPrim (fun args ->
+        let content = expect_string "writeFile" (List.hd args) in
+        try
+          let oc = open_out path in
+          output_string oc content;
+          close_out oc;
+          VBool true
+        with Sys_error msg -> raise (RuntimeError ("writeFile: " ^ msg)))))
+  |> StringMap.add "appendFile" (VPrim (fun args ->
+      let path = expect_string "appendFile" (List.hd args) in
+      VPrim (fun args ->
+        let content = expect_string "appendFile" (List.hd args) in
+        try
+          let oc = open_out_gen [Open_append; Open_creat] 0o644 path in
+          output_string oc content;
+          close_out oc;
+          VBool true
+        with Sys_error msg -> raise (RuntimeError ("appendFile: " ^ msg)))))
+  |> StringMap.add "fileExists" (VPrim (fun args ->
+      let path = expect_string "fileExists" (List.hd args) in
+      VBool (Sys.file_exists path)))
+  |> StringMap.add "deleteFile" (VPrim (fun args ->
+      let path = expect_string "deleteFile" (List.hd args) in
+      try Sys.remove path; VBool true
+      with Sys_error msg -> raise (RuntimeError ("deleteFile: " ^ msg))))
+  |> StringMap.add "readLines" (VPrim (fun args ->
+      let path = expect_string "readLines" (List.hd args) in
+      try
+        let ic = open_in path in
+        let rec read_all acc =
+          try read_all (input_line ic :: acc)
+          with End_of_file -> close_in ic; List.rev acc
+        in
+        VList (List.map (fun s -> VString s) (read_all []))
+      with Sys_error msg -> raise (RuntimeError ("readLines: " ^ msg))))
+  |> StringMap.add "writeLines" (VPrim (fun args ->
+      let path = expect_string "writeLines" (List.hd args) in
+      VPrim (fun args ->
+        let lines = match List.hd args with
+          | VList vs -> List.map (fun v -> match v with
+              | VString s -> s
+              | _ -> raise (RuntimeError "writeLines: expected list of strings")) vs
+          | _ -> raise (RuntimeError "writeLines: expected list")
+        in
+        try
+          let oc = open_out path in
+          List.iter (fun s -> output_string oc s; output_char oc '\n') lines;
+          close_out oc;
+          VBool true
+        with Sys_error msg -> raise (RuntimeError ("writeLines: " ^ msg)))))
+
 (* List primitives *)
 (* Forward reference for eval — set by eval_with_imports at startup *)
 let eval_ref : (env -> expr -> env * value) ref = ref (fun _ _ -> failwith "eval not initialized")
@@ -479,6 +548,7 @@ let rec eval_with_imports env expr =
         | "string" -> create_string_functions env
         | "list" -> create_list_functions env
         | "time" -> create_time_functions env
+        | "io" -> create_io_functions env
         | _ -> env
       in
       imported_libraries := StringMap.add lib_name true !imported_libraries;
@@ -682,7 +752,7 @@ let rec eval_toplevel (env : env) (expr : expr) : env * value option =
       (env, Some v)
 
 let load_prelude () =
-  let stdlib = ["operators"; "math"; "string"; "list"; "time"; "church_list"; "result"] in
+  let stdlib = ["operators"; "math"; "string"; "list"; "time"; "io"; "church_list"; "result"] in
   List.fold_left (fun env lib ->
     fst (eval_with_imports env (Import lib))
   ) StringMap.empty stdlib

--- a/src/infer.ml
+++ b/src/infer.ml
@@ -159,6 +159,15 @@ let add_operators_to_env env =
   let env = StringMap.add "dayOfWeek" (mono (TFun (TInt, TInt))) env in
   let env = StringMap.add "diffTime" (mono (TFun (TInt, TFun (TInt, TInt)))) env in
 
+  (* File I/O functions *)
+  let env = StringMap.add "readFile" (mono (TFun (TString, TString))) env in
+  let env = StringMap.add "writeFile" (mono (TFun (TString, TFun (TString, TBool)))) env in
+  let env = StringMap.add "appendFile" (mono (TFun (TString, TFun (TString, TBool)))) env in
+  let env = StringMap.add "fileExists" (mono (TFun (TString, TBool))) env in
+  let env = StringMap.add "deleteFile" (mono (TFun (TString, TBool))) env in
+  let env = StringMap.add "readLines" (mono (TFun (TString, TList TString))) env in
+  let env = StringMap.add "writeLines" (mono (TFun (TString, TFun (TList TString, TBool)))) env in
+
   (* List operations — polymorphic via fresh vars *)
   let a1 = fresh_var () in
   let env = StringMap.add "cons" (mono (TFun (a1, TFun (TList a1, TList a1)))) env in

--- a/src/lib/io.ch
+++ b/src/lib/io.ch
@@ -1,0 +1,30 @@
+# I/O Library
+# Native primitives: readFile, writeFile, appendFile, fileExists,
+#   deleteFile, readLines, writeLines
+
+# Church-encoded IO monad
+# An IO action is a lambda that performs the effect when applied to a dummy arg:
+#   IO a = |>_. a  (thunk)
+
+# Wrap a pure value as an IO action
+~pureIO v (|>_. v)
+
+# Bind: run first action, pass result to function that returns next action
+~bindIO action,f (|>_. (f (action 0)) 0)
+
+# Map: transform the result of an IO action
+~mapIO f,action (|>_. f (action 0))
+
+# Sequence: run two actions, return result of second
+~seqIO a,b (|>_. a 0, b 0)
+
+# Lift native I/O into IO monad
+~readFileIO path (|>_. readFile path)
+~writeFileIO path,content (|>_. writeFile path content)
+~appendFileIO path,content (|>_. appendFile path content)
+~deleteFileIO path (|>_. deleteFile path)
+~readLinesIO path (|>_. readLines path)
+~writeLinesIO path,lines (|>_. writeLines path lines)
+
+# Run an IO action (extract the value)
+~runIO action (action 0)

--- a/src/test/27_file_io.ch
+++ b/src/test/27_file_io.ch
@@ -1,0 +1,37 @@
+# Test file I/O (Option A — native primitives)
+
+@test_path "/tmp/churing_test_27.txt"
+@test_path2 "/tmp/churing_test_27_lines.txt"
+
+~(
+    # Write a file
+    assert (writeFile test_path "hello world")
+
+    # File exists
+    assert (fileExists test_path)
+
+    # Read it back
+    assert (eq (readFile test_path) "hello world")
+
+    # Append to it
+    assert (appendFile test_path " more")
+    assert (eq (readFile test_path) "hello world more")
+
+    # Write lines
+    assert (writeLines test_path2 ["line1", "line2", "line3"])
+
+    # Read lines
+    @lines (readLines test_path2)
+    assert (eq (len lines) 3)
+    assert (eq (head lines) "line1")
+    assert (eq (nth lines 2) "line3")
+
+    # Delete files
+    assert (deleteFile test_path)
+    assert (not (fileExists test_path))
+    assert (deleteFile test_path2)
+
+    # Error handling with try
+    @result (try (readFile "/tmp/nonexistent_churing_file") (|>e. "caught"))
+    assert (eq result "caught")
+)

--- a/src/test/28_io_monad.ch
+++ b/src/test/28_io_monad.ch
@@ -1,0 +1,26 @@
+# Test Church-encoded IO monad (Option B)
+
+@test_path "/tmp/churing_test_28.txt"
+
+~(
+    # pureIO wraps a value
+    assert (eq (runIO (pureIO 42)) 42)
+
+    # writeFileIO + readFileIO via bindIO
+    @program (bindIO (writeFileIO test_path "monadic hello")
+        (|>_. readFileIO test_path))
+    assert (eq (runIO program) "monadic hello")
+
+    # mapIO transforms result
+    @upper_program (mapIO uppercase (readFileIO test_path))
+    assert (eq (runIO upper_program) "MONADIC HELLO")
+
+    # Chain multiple actions
+    @chain (bindIO (writeFileIO test_path "step1")
+        (|>_. bindIO (appendFileIO test_path " step2")
+            (|>_. readFileIO test_path)))
+    assert (eq (runIO chain) "step1 step2")
+
+    # Cleanup
+    assert (deleteFile test_path)
+)


### PR DESCRIPTION
## Summary

### Option A — Native primitives
```
@content (readFile "data.txt")
assert (writeFile "out.txt" content)
```
Functions: `readFile`, `writeFile`, `appendFile`, `fileExists`, `deleteFile`, `readLines`, `writeLines`. Errors handled via `try`.

### Option B — Church-encoded IO monad
```
@program (bindIO (readFileIO "data.txt")
    (|>content. writeFileIO "out.txt" (uppercase content)))
runIO program
```
Monadic interface: `pureIO`, `bindIO`, `mapIO`, `seqIO`, `runIO` + IO-lifted versions of all native primitives.

Closes #13

## Test plan
- [x] All 41 OCaml unit tests pass
- [x] All 28 integration tests pass (new: `27_file_io.ch`, `28_io_monad.ch`)