### PR TITLE
Update documentation to reflect current language state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,15 +6,17 @@ A functional programming language named after Alonzo Church and Alan Turing, imp
 
 - `src/churing.ml` — Entry point: parse → type-infer → evaluate
 - `src/parser.ml` — Lexer, parser, and `parse_and_infer` (type errors are non-fatal warnings)
-- `src/ast.ml` — AST: Int, Lng, Float, Str, Bool, Add, Sub, Mul, Div, Eq, Var, Lam, App, Let, FunDef, Seq, Print, Assert, Import
-- `src/eval.ml` — Evaluator: environment-based closures, VRecFun for recursion, VTailCall trampoline for TCO
+- `src/ast.ml` — AST: Int, Lng, Float, Str, Bool, Add, Sub, Mul, Div, Eq, Var, Lam, App, Let, FunDef, Seq, Assert, List, Match, Try, Import
+- `src/eval.ml` — Evaluator: environment-based closures, VRecFun for recursion, VTailCall trampoline for TCO, VList/VCons/VNil for lists
 - `src/infer.ml` — Hindley-Milner type inference with unification and type schemes
-- `src/types.ml` — Type definitions (TInt, TLong, TFloat, TString, TBool, TVar, TFun, TUnknown)
-- `src/lib/` — Standard libraries (operators.ch)
-- `src/test/` — Integration tests: `*.ch` files, assert-based or with `*.ch.out` for output diff
+- `src/types.ml` — Type definitions (TInt, TLong, TFloat, TString, TBool, TVar, TFun, TList, TUnknown)
+- `src/lib/` — Standard library `.ch` files (auto-loaded at startup)
+- `src/test/` — Integration tests: `*.ch` files, assert-based
 - `test/` — OCaml unit tests (Alcotest): parser, evaluator, type inference
 
 ## Language Syntax
+
+Programs are pure: the last expression is the program's return value (auto-printed). No `print`, no `~()` main block required.
 
 ```
 ~name arg1,arg2  body        # Named function (comma-separated args)
@@ -22,21 +24,23 @@ A functional programming language named after Alonzo Church and Alan Turing, imp
 @name value                  # Variable declaration (@x 5)
 eq a b                       # Equality (returns boolean)
 assert expr                  # Assertion (fails with exit 1 if false)
-match expr | pat -> body     # Pattern matching
-try expr (|>err. handler)    # Error handling
+match expr | pat -> body     # Pattern matching (literals, variables, wildcards, lists, cons)
+try expr (|>err. handler)    # Error handling (catches runtime errors)
 [1, 2, 3]                   # List literal
+h :: t                       # Cons pattern (head :: tail destructuring)
 import "lib"                 # Import custom library (stdlib is auto-loaded)
 ```
 
 ## Standard Library (auto-loaded)
 
-All standard library functions are available without imports:
+All standard library functions are available without imports. Each library has native primitives (OCaml) plus Churing-level helpers in `src/lib/*.ch`.
 
 - **operators**: true, false, not, and, or, if, identity, const, flip, compose
-- **math**: sqrt, sin, cos, tan, asin, acos, atan, floor, ceil, round, abs, pow, min, max, pi, e, square, cube, clamp, lerp
-- **string**: length, concat, substring, uppercase, lowercase, trim, charAt, indexOf, startsWith, endsWith, replace, toString, isEmpty, contains, repeat
+- **math**: sqrt, sin, cos, tan, asin, acos, atan, floor, ceil, round, abs, pow, min, max, pi, e, square, cube, sign, clamp, lerp
+- **string**: length, concat, substring, uppercase, lowercase, trim, charAt, indexOf, startsWith, endsWith, replace, toString, isEmpty, contains, repeat, padLeft
 - **list**: nil, cons, head, tail, empty, len, nth, reverse, range, map, filter, foldl, foldr, matchList, matchBool, sum, product, any, all, take, drop, zip, flatten, append
 - **time**: now, timeMs, year, month, day, hour, minute, second, dayOfWeek, diffTime, isLeapYear
+- **io**: readFile, writeFile, appendFile, fileExists, deleteFile, readLines, writeLines, pureIO, bindIO, mapIO, seqIO, runIO, readFileIO, writeFileIO, appendFileIO, deleteFileIO, readLinesIO, writeLinesIO
 - **church_list**: church_nil, church_cons, church_head, church_sum, church_map, church_fold, church_length
 - **result**: ok, err, matchResult, mapResult, bindResult, unwrapOr, isOk, isErr
 
@@ -57,8 +61,8 @@ The script mounts the local source as a volume, so file changes are picked up wi
 
 ## Testing Conventions
 
-- Assert-based tests: `src/test/NN_name.ch` with `assert` statements, no `.out` file needed
-- Output-based tests: `src/test/NN_name.ch` with expected output in `src/test/NN_name.ch.out`
+- Assert-based tests: `src/test/NN_name.ch` with `assert` statements (primary approach)
+- Output-based tests: `src/test/NN_name.ch` with expected output in `src/test/NN_name.ch.out` (for testing last-value output)
 - OCaml unit tests: `test/test_parser.ml`, `test/test_eval.ml`, `test/test_infer.ml`
 - CI runs `dune runtest` (unit tests) then integration tests
 

--- a/README.md
+++ b/README.md
@@ -2,77 +2,111 @@
 
 A functional programming language named after [Alonzo Church](https://en.wikipedia.org/wiki/Alonzo_Church) and [Alan Turing](https://en.wikipedia.org/wiki/Alan_Turing) — the founders of computation theory. Church invented lambda calculus; Turing defined the universal machine. Churing brings both ideas together in one language.
 
+## Quick Example
+
+```
+~fib n (match n | 0 -> 0 | 1 -> 1 | x -> fib (x - 1) + fib (x - 2))
+
+fib 10
+```
+Output: `55`
+
+No boilerplate — define functions and reduce to a value. The last expression is the program's return value.
+
 ## Core Features
 
+### Pure Lambda Calculus Feel
+- No `print` — programs reduce to a single return value
+- No `main` block required — top-level expressions execute directly
+- Standard library auto-loaded — no import statements needed
+- Church-style booleans: `true a b = a`, `false a b = b`
+
 ### Type System
-- Basic types: `Int`, `Long` (64-bit integers), `Float`, `Bool`, `String`
-- Function types
+- Basic types: `Int`, `Long` (64-bit), `Float`, `Bool`, `String`, `List`
+- Function types (curried)
 - Hindley-Milner type inference with let-polymorphism
+
+### Pattern Matching
+```
+~eval expr (match expr
+    | 0 -> "zero"
+    | n -> concat "number: " (toString n))
+
+~len l (match l
+    | [] -> 0
+    | h :: t -> 1 + len t)
+```
+Patterns: literals, variables, wildcards (`_`), lists (`[x, y]`), cons destructuring (`h :: t`).
+
+### Lists (Three Approaches)
+```
+# Native lists with literal syntax
+@nums [1, 2, 3, 4, 5]
+map (|>x. x * 2) nums              # [2, 4, 6, 8, 10]
+foldl (|>acc. |>x. acc + x) 0 nums # 15
+
+# Cons cells (Lisp-style)
+cons 0 nums                         # [0, 1, 2, 3, 4, 5]
+
+# Church-encoded lists (pure lambda calculus)
+@cl (church_cons 1 (church_cons 2 church_nil))
+church_sum cl                       # 3
+```
+
+### Error Handling (Two Approaches)
+```
+# try/catch primitive
+@safe (try (readFile "missing.txt") (|>err. "default"))
+
+# Church-encoded Result type
+@result (ok 42)
+unwrapOr 0 result                   # 42
+```
 
 ### Expressions
 - Numeric literals: integers (`123`), longs (`123L`), floats (`3.14`, `.5`, `123f`)
-- String literals (in double quotes: `"hello"`)
+- String literals (`"hello"`)
 - Boolean literals (`true`, `false`)
-- Variables
 - Lambda functions (`|>x. body`)
-- Function application
-- Arithmetic operations (`+`, `-`, `*`, `/`) with proper precedence
-- Equality testing (`eq`)
+- Curried function application
+- Arithmetic (`+`, `-`, `*`, `/`) with proper precedence
+- Equality (`eq`)
 - Assertions (`assert`)
 
 ### Declarations
-- Variable declarations with type inference (`@i_x 5` for int, `@s_name "hello"` for string)
-- Named function definitions (`~add x,y x + y`)
-- Recursive functions with tail call optimization
-
-### I/O
-- `print` expression for output
-- `import` for loading libraries
-
-## Syntax Examples
-
 ```
-# Variable declarations
-@i_v1 4        # Integer
-@l_v3 4L       # Long integer
-@f_v5 2.4      # Float
-@s_v2 "string" # String
-
-# Function definitions
-~add x,y x + y
-~factorial n (
-    (eq n 0 (|>_. 1) (|>_. n * factorial (n - 1))) 0
-)
-
-# Lambda expressions
-~compose f,g,x (f (g x))
-
-# Main program block
-~(
-    print (add 2 3)
-    assert (eq (factorial 5) 120)
-    print (compose (|>x. x + 1) (|>x. x * 10) 3)
-)
+@x 5                        # Variable (type inferred)
+~add x,y x + y              # Named function (comma-separated args)
+~fact n (match n             # Recursive (with tail call optimization)
+    | 0 -> 1
+    | n -> n * fact (n - 1))
 ```
+
+## Standard Library
+
+All functions are available without imports:
+
+| Library | Functions |
+|---------|-----------|
+| **operators** | `true`, `false`, `not`, `and`, `or`, `if`, `identity`, `const`, `flip`, `compose` |
+| **math** | `sqrt`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `floor`, `ceil`, `round`, `abs`, `pow`, `min`, `max`, `pi`, `e`, `square`, `cube`, `sign`, `clamp`, `lerp` |
+| **string** | `length`, `concat`, `substring`, `uppercase`, `lowercase`, `trim`, `charAt`, `indexOf`, `startsWith`, `endsWith`, `replace`, `toString`, `isEmpty`, `contains`, `repeat`, `padLeft` |
+| **list** | `nil`, `cons`, `head`, `tail`, `empty`, `len`, `nth`, `reverse`, `range`, `map`, `filter`, `foldl`, `foldr`, `matchList`, `matchBool`, `sum`, `product`, `any`, `all`, `take`, `drop`, `zip`, `flatten`, `append` |
+| **time** | `now`, `timeMs`, `year`, `month`, `day`, `hour`, `minute`, `second`, `dayOfWeek`, `diffTime`, `isLeapYear` |
+| **io** | `readFile`, `writeFile`, `appendFile`, `fileExists`, `deleteFile`, `readLines`, `writeLines`, `pureIO`, `bindIO`, `mapIO`, `runIO` |
+| **result** | `ok`, `err`, `matchResult`, `mapResult`, `bindResult`, `unwrapOr`, `isOk`, `isErr` |
+| **church_list** | `church_nil`, `church_cons`, `church_head`, `church_sum`, `church_map`, `church_fold`, `church_length` |
 
 ## Implementation
 
-Churing is implemented in OCaml with several key components:
+Churing is implemented in OCaml:
 
-1. **Lexer/Parser** (`parser.ml`): Tokenizes and parses source code into an AST
-2. **AST** (`ast.ml`): Defines the abstract syntax tree
-3. **Type System** (`types.ml`): Defines types, schemes, and type operations
-4. **Type Inference** (`infer.ml`): Implements Hindley-Milner type inference with unification
-5. **Evaluator** (`eval.ml`): Interprets the AST with closures, recursion, and tail call optimization
-
-## Features
-
-- **Type inference**: Types are inferred automatically via Hindley-Milner
-- **First-class functions**: Functions can be passed as arguments and returned as values
-- **Tail call optimization**: Deep recursion without stack overflow
-- **Native booleans**: `true`/`false` with Church-style applicability (`true a b = a`)
-- **Assertions**: Built-in `assert` for self-checking tests
-- **Smart number formatting**: Whole number results displayed without decimal points
+1. **Lexer/Parser** (`src/parser.ml`) — Tokenizes and parses source into an AST
+2. **AST** (`src/ast.ml`) — Abstract syntax tree with pattern matching support
+3. **Type System** (`src/types.ml`) — Types, schemes, and type operations including `TList`
+4. **Type Inference** (`src/infer.ml`) — Hindley-Milner with unification, generalization, and polymorphic list operations
+5. **Evaluator** (`src/eval.ml`) — Environment-based interpreter with closures, recursion, tail call optimization, native lists, cons cells, and pattern matching
+6. **Standard Library** (`src/lib/*.ch`) — Hybrid: native OCaml primitives + Churing-level helpers
 
 ## Usage
 
@@ -92,4 +126,10 @@ docker build -t churing-test .
 
 ## Design Philosophy
 
-Churing honours its namesakes by combining Church's lambda calculus with Turing's practical computability. It serves as both an educational tool for understanding functional programming and a testbed for language implementation techniques — parsing, type inference, closures, and tail call optimization.
+Churing honours its namesakes by combining Church's lambda calculus with Turing's practical computability. The language aims to feel like pure lambda calculus — programs are expressions that reduce to values — while providing practical features (pattern matching, lists, I/O, error handling) through both native primitives and Church-encoded alternatives.
+
+Every major feature offers two approaches:
+- **Native** — practical and efficient
+- **Church-encoded** — pure lambda calculus, implemented in Churing itself
+
+This lets users choose their level of abstraction: use native lists for convenience, or Church-encoded lists to stay true to lambda calculus.


### PR DESCRIPTION
## Summary
- Update README.md and CLAUDE.md to reflect all changes since the initial documentation
- Remove outdated references: `print`, type prefixes (`@i_x`), `~()` main block
- Document all current features: pattern matching, lists (3 approaches), error handling (2 approaches), file I/O (2 approaches), time, auto-loaded prelude
- Add quick example showing the pure lambda calculus feel
- Document the dual approach philosophy (native + Church-encoded)
- Complete standard library reference table

## Test plan
- [x] All tests still pass (documentation-only change)