### PR TITLE
Add comparison operators, string interpolation, dictionaries, and JSON

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -17,6 +17,7 @@ type expr =
   | Seq of expr * expr
   | Assert of expr
   | List of expr list
+  | Dict of (string * expr) list
   | Match of expr * (pattern * expr) list
   | Try of expr * expr
   | Import of string
@@ -40,6 +41,7 @@ let rec string_of_typ = function
   | Types.TVar v -> "'" ^ v
   | Types.TFun (a, b) -> "(" ^ string_of_typ a ^ " -> " ^ string_of_typ b ^ ")"
   | Types.TList a -> "[" ^ string_of_typ a ^ "]"
+  | Types.TDict a -> "{String: " ^ string_of_typ a ^ "}"
 
 let rec string_of_expr = function
   | Int n -> string_of_int n
@@ -62,6 +64,8 @@ let rec string_of_expr = function
   | Seq (a, b) -> string_of_expr a ^ ";\n" ^ string_of_expr b
   | Assert e -> "assert " ^ string_of_expr e
   | List es -> "[" ^ String.concat ", " (List.map string_of_expr es) ^ "]"
+  | Dict entries ->
+      "{" ^ String.concat ", " (List.map (fun (k, v) -> k ^ ": " ^ string_of_expr v) entries) ^ "}"
   | Match (e, arms) ->
       "match " ^ string_of_expr e ^ " " ^
       String.concat " " (List.map (fun (p, body) ->

--- a/src/eval.ml
+++ b/src/eval.ml
@@ -11,6 +11,7 @@ type value =
   | VList of value list
   | VCons of value * value
   | VNil
+  | VDict of (string * value) list
   | VFun of string list * expr * env
   | VRecFun of string * string list * expr * env  (* name * args * body * env — binds itself at call time *)
   | VPrim of (value list -> value)
@@ -74,6 +75,8 @@ let rec string_of_value = function
   | VList vs -> "[" ^ String.concat ", " (List.map string_of_value vs) ^ "]"
   | VCons _ as c -> string_of_cons c
   | VNil -> "nil"
+  | VDict entries ->
+      "{" ^ String.concat ", " (List.map (fun (k, v) -> k ^ ": " ^ string_of_value v) entries) ^ "}"
   | VTailCall _ -> "<tailcall>"
   | VRecFun _ | _ -> "<fun>"
 
@@ -115,6 +118,63 @@ let create_church_booleans env =
   |> StringMap.add "and" and_fn
   |> StringMap.add "or" or_fn
   |> StringMap.add "if" if_fn
+  (* Comparison operators — work on numeric and string values *)
+  |> StringMap.add "gt" (VPrim (fun args ->
+      let a = List.hd args in
+      VPrim (fun args ->
+        let b = List.hd args in
+        VBool (match a, b with
+          | VInt x, VInt y -> x > y
+          | VFloat x, VFloat y -> x > y
+          | VInt x, VFloat y -> float_of_int x > y
+          | VFloat x, VInt y -> x > float_of_int y
+          | VLong x, VLong y -> Int64.compare x y > 0
+          | VInt x, VLong y -> Int64.compare (Int64.of_int x) y > 0
+          | VLong x, VInt y -> Int64.compare x (Int64.of_int y) > 0
+          | VString x, VString y -> String.compare x y > 0
+          | _ -> raise (RuntimeError "gt: incompatible types")))))
+  |> StringMap.add "lt" (VPrim (fun args ->
+      let a = List.hd args in
+      VPrim (fun args ->
+        let b = List.hd args in
+        VBool (match a, b with
+          | VInt x, VInt y -> x < y
+          | VFloat x, VFloat y -> x < y
+          | VInt x, VFloat y -> float_of_int x < y
+          | VFloat x, VInt y -> x < float_of_int y
+          | VLong x, VLong y -> Int64.compare x y < 0
+          | VInt x, VLong y -> Int64.compare (Int64.of_int x) y < 0
+          | VLong x, VInt y -> Int64.compare x (Int64.of_int y) < 0
+          | VString x, VString y -> String.compare x y < 0
+          | _ -> raise (RuntimeError "lt: incompatible types")))))
+  |> StringMap.add "gte" (VPrim (fun args ->
+      let a = List.hd args in
+      VPrim (fun args ->
+        let b = List.hd args in
+        VBool (match a, b with
+          | VInt x, VInt y -> x >= y
+          | VFloat x, VFloat y -> x >= y
+          | VInt x, VFloat y -> float_of_int x >= y
+          | VFloat x, VInt y -> x >= float_of_int y
+          | VLong x, VLong y -> Int64.compare x y >= 0
+          | VInt x, VLong y -> Int64.compare (Int64.of_int x) y >= 0
+          | VLong x, VInt y -> Int64.compare x (Int64.of_int y) >= 0
+          | VString x, VString y -> String.compare x y >= 0
+          | _ -> raise (RuntimeError "gte: incompatible types")))))
+  |> StringMap.add "lte" (VPrim (fun args ->
+      let a = List.hd args in
+      VPrim (fun args ->
+        let b = List.hd args in
+        VBool (match a, b with
+          | VInt x, VInt y -> x <= y
+          | VFloat x, VFloat y -> x <= y
+          | VInt x, VFloat y -> float_of_int x <= y
+          | VFloat x, VInt y -> x <= float_of_int y
+          | VLong x, VLong y -> Int64.compare x y <= 0
+          | VInt x, VLong y -> Int64.compare (Int64.of_int x) y <= 0
+          | VLong x, VInt y -> Int64.compare x (Int64.of_int y) <= 0
+          | VString x, VString y -> String.compare x y <= 0
+          | _ -> raise (RuntimeError "lte: incompatible types")))))
 
 (* Math primitives *)
 let create_math_functions env =
@@ -249,6 +309,22 @@ let create_string_functions env =
       | VBool true -> VString "true"
       | VBool false -> VString "false"
       | v -> VString (string_of_value v)))
+  (* str: concatenate a list of values into a string (auto-converts each) *)
+  |> StringMap.add "str" (VPrim (fun args ->
+      match List.hd args with
+      | VList vs ->
+          VString (String.concat "" (List.map string_of_value vs))
+      | v -> VString (string_of_value v)))
+  (* join: join a list of values with a separator *)
+  |> StringMap.add "join" (VPrim (fun args ->
+      let sep = (match List.hd args with
+        | VString s -> s
+        | _ -> raise (RuntimeError "join: separator must be a string")) in
+      VPrim (fun args ->
+        match List.hd args with
+        | VList vs ->
+            VString (String.concat sep (List.map string_of_value vs))
+        | _ -> raise (RuntimeError "join: expected list"))))
 
 (* Date/Time primitives *)
 let create_time_functions env =
@@ -288,6 +364,168 @@ let create_time_functions env =
       VInt tm.Unix.tm_wday))
 
 (* File I/O primitives *)
+(* Dict primitives *)
+let create_dict_functions env =
+  let expect_string name = function
+    | VString s -> s
+    | _ -> raise (RuntimeError (name ^ ": expected string"))
+  in
+  let expect_dict name = function
+    | VDict entries -> entries
+    | _ -> raise (RuntimeError (name ^ ": expected dict"))
+  in
+  env
+  |> StringMap.add "get" (VPrim (fun args ->
+      let d = expect_dict "get" (List.hd args) in
+      VPrim (fun args ->
+        let k = expect_string "get" (List.hd args) in
+        match List.assoc_opt k d with
+        | Some v -> v
+        | None -> raise (RuntimeError ("get: key not found: " ^ k)))))
+  |> StringMap.add "set" (VPrim (fun args ->
+      let d = expect_dict "set" (List.hd args) in
+      VPrim (fun args ->
+        let k = expect_string "set" (List.hd args) in
+        VPrim (fun args ->
+          let v = List.hd args in
+          let d' = List.filter (fun (k', _) -> k' <> k) d in
+          VDict ((k, v) :: d')))))
+  |> StringMap.add "has" (VPrim (fun args ->
+      let d = expect_dict "has" (List.hd args) in
+      VPrim (fun args ->
+        let k = expect_string "has" (List.hd args) in
+        VBool (List.assoc_opt k d <> None))))
+  |> StringMap.add "keys" (VPrim (fun args ->
+      let d = expect_dict "keys" (List.hd args) in
+      VList (List.map (fun (k, _) -> VString k) d)))
+  |> StringMap.add "values" (VPrim (fun args ->
+      let d = expect_dict "values" (List.hd args) in
+      VList (List.map (fun (_, v) -> v) d)))
+  |> StringMap.add "merge" (VPrim (fun args ->
+      let d1 = expect_dict "merge" (List.hd args) in
+      VPrim (fun args ->
+        let d2 = expect_dict "merge" (List.hd args) in
+        let merged = List.fold_left (fun acc (k, v) ->
+          if List.assoc_opt k acc <> None then acc
+          else (k, v) :: acc) d2 d1 in
+        VDict merged)))
+  |> StringMap.add "remove" (VPrim (fun args ->
+      let d = expect_dict "remove" (List.hd args) in
+      VPrim (fun args ->
+        let k = expect_string "remove" (List.hd args) in
+        VDict (List.filter (fun (k', _) -> k' <> k) d))))
+  |> StringMap.add "entries" (VPrim (fun args ->
+      let d = expect_dict "entries" (List.hd args) in
+      VList (List.map (fun (k, v) -> VList [VString k; v]) d)))
+  |> StringMap.add "fromEntries" (VPrim (fun args ->
+      match List.hd args with
+      | VList pairs ->
+          VDict (List.map (fun pair ->
+            match pair with
+            | VList [VString k; v] -> (k, v)
+            | _ -> raise (RuntimeError "fromEntries: expected [key, value] pairs")
+          ) pairs)
+      | _ -> raise (RuntimeError "fromEntries: expected list")))
+
+(* JSON primitives *)
+let rec value_to_json = function
+  | VInt n -> string_of_int n
+  | VLong n -> Int64.to_string n
+  | VFloat f ->
+      if Float.equal (Float.round f) f then string_of_int (int_of_float f)
+      else string_of_float f
+  | VString s -> "\"" ^ String.concat "" (List.map (fun c ->
+      match c with
+      | '"' -> "\\\""
+      | '\\' -> "\\\\"
+      | '\n' -> "\\n"
+      | '\t' -> "\\t"
+      | c -> String.make 1 c
+    ) (List.init (String.length s) (String.get s))) ^ "\""
+  | VBool true -> "true"
+  | VBool false -> "false"
+  | VNil -> "null"
+  | VList vs -> "[" ^ String.concat "," (List.map value_to_json vs) ^ "]"
+  | VDict entries ->
+      "{" ^ String.concat "," (List.map (fun (k, v) ->
+        "\"" ^ k ^ "\":" ^ value_to_json v) entries) ^ "}"
+  | _ -> "null"
+
+(* Simple recursive-descent JSON parser *)
+let json_to_value s =
+  let len = String.length s in
+  let rec skip_ws i = if i < len && (s.[i] = ' ' || s.[i] = '\t' || s.[i] = '\n' || s.[i] = '\r') then skip_ws (i+1) else i in
+  let rec parse_value i =
+    let i = skip_ws i in
+    if i >= len then raise (RuntimeError "fromJson: unexpected end of input")
+    else if s.[i] = '"' then parse_string (i+1) (Buffer.create 16)
+    else if s.[i] = '[' then parse_array (i+1) []
+    else if s.[i] = '{' then parse_object (i+1) []
+    else if s.[i] = 't' && i+3 < len && String.sub s i 4 = "true" then (VBool true, i+4)
+    else if s.[i] = 'f' && i+4 < len && String.sub s i 5 = "false" then (VBool false, i+5)
+    else if s.[i] = 'n' && i+3 < len && String.sub s i 4 = "null" then (VNil, i+4)
+    else if s.[i] = '-' || (s.[i] >= '0' && s.[i] <= '9') then parse_number i
+    else raise (RuntimeError (Printf.sprintf "fromJson: unexpected char '%c' at %d" s.[i] i))
+  and parse_string i buf =
+    if i >= len then raise (RuntimeError "fromJson: unterminated string")
+    else if s.[i] = '"' then (VString (Buffer.contents buf), i+1)
+    else if s.[i] = '\\' && i+1 < len then (
+      (match s.[i+1] with
+       | '"' -> Buffer.add_char buf '"'
+       | '\\' -> Buffer.add_char buf '\\'
+       | 'n' -> Buffer.add_char buf '\n'
+       | 't' -> Buffer.add_char buf '\t'
+       | '/' -> Buffer.add_char buf '/'
+       | c -> Buffer.add_char buf '\\'; Buffer.add_char buf c);
+      parse_string (i+2) buf)
+    else (Buffer.add_char buf s.[i]; parse_string (i+1) buf)
+  and parse_number i =
+    let j = ref i in
+    let is_float = ref false in
+    if !j < len && s.[!j] = '-' then incr j;
+    while !j < len && s.[!j] >= '0' && s.[!j] <= '9' do incr j done;
+    if !j < len && s.[!j] = '.' then (is_float := true; incr j;
+      while !j < len && s.[!j] >= '0' && s.[!j] <= '9' do incr j done);
+    if !j < len && (s.[!j] = 'e' || s.[!j] = 'E') then (is_float := true; incr j;
+      if !j < len && (s.[!j] = '+' || s.[!j] = '-') then incr j;
+      while !j < len && s.[!j] >= '0' && s.[!j] <= '9' do incr j done);
+    let num_str = String.sub s i (!j - i) in
+    if !is_float then (VFloat (float_of_string num_str), !j)
+    else (VInt (int_of_string num_str), !j)
+  and parse_array i acc =
+    let i = skip_ws i in
+    if i < len && s.[i] = ']' then (VList (List.rev acc), i+1)
+    else
+      let v, i = parse_value i in
+      let i = skip_ws i in
+      if i < len && s.[i] = ',' then parse_array (i+1) (v :: acc)
+      else if i < len && s.[i] = ']' then (VList (List.rev (v :: acc)), i+1)
+      else raise (RuntimeError "fromJson: expected ',' or ']' in array")
+  and parse_object i acc =
+    let i = skip_ws i in
+    if i < len && s.[i] = '}' then (VDict (List.rev acc), i+1)
+    else if i < len && s.[i] = '"' then
+      let key_v, i = parse_string (i+1) (Buffer.create 16) in
+      let key = match key_v with VString k -> k | _ -> failwith "impossible" in
+      let i = skip_ws i in
+      if i >= len || s.[i] <> ':' then raise (RuntimeError "fromJson: expected ':' after key");
+      let v, i = parse_value (i+1) in
+      let i = skip_ws i in
+      if i < len && s.[i] = ',' then parse_object (i+1) ((key, v) :: acc)
+      else if i < len && s.[i] = '}' then (VDict (List.rev ((key, v) :: acc)), i+1)
+      else raise (RuntimeError "fromJson: expected ',' or '}' in object")
+    else raise (RuntimeError "fromJson: expected key string in object")
+  in
+  fst (parse_value (skip_ws 0))
+
+let create_json_functions env =
+  env
+  |> StringMap.add "toJson" (VPrim (fun args -> VString (value_to_json (List.hd args))))
+  |> StringMap.add "fromJson" (VPrim (fun args ->
+      match List.hd args with
+      | VString s -> json_to_value s
+      | _ -> raise (RuntimeError "fromJson: expected string")))
+
 let create_io_functions env =
   let expect_string name = function
     | VString s -> s
@@ -549,6 +787,8 @@ let rec eval_with_imports env expr =
         | "list" -> create_list_functions env
         | "time" -> create_time_functions env
         | "io" -> create_io_functions env
+        | "dict" -> create_dict_functions env
+        | "json" -> create_json_functions env
         | _ -> env
       in
       imported_libraries := StringMap.add lib_name true !imported_libraries;
@@ -584,6 +824,12 @@ let rec eval_with_imports env expr =
         (e', acc @ [force v])
       ) (env, []) items in
       (env', VList vs)
+  | Dict entries ->
+      let env', pairs = List.fold_left (fun (e, acc) (key, expr) ->
+        let e', v = eval_with_imports e expr in
+        (e', acc @ [(key, force v)])
+      ) (env, []) entries in
+      (env', VDict pairs)
   | Add (a, b) -> eval_binop env a b ( + ) Int64.add ( +. ) "add"
   | Sub (a, b) -> eval_binop env a b ( - ) Int64.sub ( -. ) "sub"
   | Mul (a, b) -> eval_binop env a b ( * ) Int64.mul ( *. ) "mul"
@@ -606,6 +852,12 @@ let rec eval_with_imports env expr =
         | VCons (h1, t1), VCons (h2, t2) ->
             values_equal h1 h2 && values_equal t1 t2
         | VNil, VNil -> true
+        | VDict a, VDict b ->
+            List.length a = List.length b &&
+            List.for_all (fun (k, v) ->
+              match List.assoc_opt k b with
+              | Some v2 -> values_equal v v2
+              | None -> false) a
         | _ -> false
       in
       let result = values_equal va vb in
@@ -752,7 +1004,7 @@ let rec eval_toplevel (env : env) (expr : expr) : env * value option =
       (env, Some v)
 
 let load_prelude () =
-  let stdlib = ["operators"; "math"; "string"; "list"; "time"; "io"; "church_list"; "result"] in
+  let stdlib = ["operators"; "math"; "string"; "list"; "time"; "io"; "dict"; "json"; "church_list"; "result"] in
   List.fold_left (fun env lib ->
     fst (eval_with_imports env (Import lib))
   ) StringMap.empty stdlib

--- a/src/infer.ml
+++ b/src/infer.ml
@@ -13,6 +13,7 @@ let rec apply subst t =
       (try List.assoc v subst with Not_found -> t)
   | TFun (a, b) -> TFun (apply subst a, apply subst b)
   | TList a -> TList (apply subst a)
+  | TDict a -> TDict (apply subst a)
   | _ -> t
 
 let compose s1 s2 =
@@ -32,6 +33,7 @@ let rec occurs v = function
   | TVar v' -> v = v'
   | TFun (a, b) -> occurs v a || occurs v b
   | TList a -> occurs v a
+  | TDict a -> occurs v a
   | _ -> false
 
 let rec unify t1 t2 =
@@ -46,6 +48,7 @@ let rec unify t1 t2 =
       let s2 = unify (apply s1 b1) (apply s1 b2) in
       compose s2 s1
   | TList a1, TList a2 -> unify a1 a2
+  | TDict a1, TDict a2 -> unify a1 a2
   | _ -> raise (TypeError ("Cannot unify types: " ^ Ast.string_of_typ t1 ^ " and " ^ Ast.string_of_typ t2))
 
 (* Scheme helpers *)
@@ -62,6 +65,7 @@ let free_vars_typ t =
     | TVar v -> if List.mem v acc then acc else v :: acc
     | TFun (a, b) -> aux (aux acc a) b
     | TList a -> aux acc a
+    | TDict a -> aux acc a
     | _ -> acc
   in aux [] t
 
@@ -86,6 +90,7 @@ let instantiate (Forall (vars, t)) =
     | TVar v as tv -> (try List.assoc v subst with Not_found -> tv)
     | TFun (a, b) -> TFun (aux a, aux b)
     | TList a -> TList (aux a)
+    | TDict a -> TDict (aux a)
     | t -> t
   in aux t
 
@@ -108,6 +113,17 @@ let add_operators_to_env env =
 
   let t_or = TFun (t_bool, TFun (t_bool, t_bool)) in
   let env = StringMap.add "or" (mono t_or) env in
+
+  (* Comparison operators — polymorphic: a -> a -> Bool *)
+  let cmp_a = fresh_var () in
+  let t_cmp = TFun (cmp_a, TFun (cmp_a, t_bool)) in
+  let env = StringMap.add "gt" (mono t_cmp) env in
+  let cmp_b = fresh_var () in
+  let env = StringMap.add "lt" (mono (TFun (cmp_b, TFun (cmp_b, t_bool)))) env in
+  let cmp_c = fresh_var () in
+  let env = StringMap.add "gte" (mono (TFun (cmp_c, TFun (cmp_c, t_bool)))) env in
+  let cmp_d = fresh_var () in
+  let env = StringMap.add "lte" (mono (TFun (cmp_d, TFun (cmp_d, t_bool)))) env in
 
   (* Math functions *)
   let t_float_float = TFun (TFloat, TFloat) in
@@ -144,6 +160,10 @@ let add_operators_to_env env =
   let env = StringMap.add "replace" (mono (TFun (t_str, TFun (t_str, TFun (t_str, t_str))))) env in
   let a = fresh_var () in
   let env = StringMap.add "toString" (mono (TFun (a, t_str))) env in
+  let str_a = fresh_var () in
+  let env = StringMap.add "str" (mono (TFun (TList str_a, t_str))) env in
+  let join_a = fresh_var () in
+  let env = StringMap.add "join" (mono (TFun (t_str, TFun (TList join_a, t_str)))) env in
 
   (* Date/Time functions *)
   let t_dummy = fresh_var () in
@@ -167,6 +187,32 @@ let add_operators_to_env env =
   let env = StringMap.add "deleteFile" (mono (TFun (TString, TBool))) env in
   let env = StringMap.add "readLines" (mono (TFun (TString, TList TString))) env in
   let env = StringMap.add "writeLines" (mono (TFun (TString, TFun (TList TString, TBool)))) env in
+
+  (* Dict operations *)
+  let d1 = fresh_var () in
+  let env = StringMap.add "get" (mono (TFun (TDict d1, TFun (TString, d1)))) env in
+  let d2 = fresh_var () in
+  let env = StringMap.add "set" (mono (TFun (TDict d2, TFun (TString, TFun (d2, TDict d2))))) env in
+  let d3 = fresh_var () in
+  let env = StringMap.add "has" (mono (TFun (TDict d3, TFun (TString, TBool)))) env in
+  let d4 = fresh_var () in
+  let env = StringMap.add "keys" (mono (TFun (TDict d4, TList TString))) env in
+  let d5 = fresh_var () in
+  let env = StringMap.add "values" (mono (TFun (TDict d5, TList d5))) env in
+  let d6 = fresh_var () in
+  let env = StringMap.add "merge" (mono (TFun (TDict d6, TFun (TDict d6, TDict d6)))) env in
+  let d7 = fresh_var () in
+  let env = StringMap.add "remove" (mono (TFun (TDict d7, TFun (TString, TDict d7)))) env in
+  let d8 = fresh_var () in
+  let env = StringMap.add "entries" (mono (TFun (TDict d8, TList (TList d8)))) env in
+  let d9 = fresh_var () in
+  let env = StringMap.add "fromEntries" (mono (TFun (TList (TList d9), TDict d9))) env in
+
+  (* JSON functions *)
+  let json_a = fresh_var () in
+  let env = StringMap.add "toJson" (mono (TFun (json_a, TString))) env in
+  let json_b = fresh_var () in
+  let env = StringMap.add "fromJson" (mono (TFun (TString, json_b))) env in
 
   (* List operations — polymorphic via fresh vars *)
   let a1 = fresh_var () in
@@ -234,6 +280,16 @@ let rec infer env = function
         (compose s2 (compose s1 s_acc), apply s2 t1)
       ) (s0, t0) xs in
       (s, TList t)
+  | Dict [] -> ([], TDict (fresh_var ()))
+  | Dict ((_, v) :: rest) ->
+      let s0, t0 = infer env v in
+      let s, t = List.fold_left (fun (s_acc, t_acc) (_, v_expr) ->
+        let s1, t1 = infer (apply_env s_acc env) v_expr in
+        let t_acc' = apply s1 t_acc in
+        let s2 = unify t_acc' t1 in
+        (compose s2 (compose s1 s_acc), apply s2 t1)
+      ) (s0, t0) rest in
+      (s, TDict t)
   | Add (a, b) | Sub (a, b) | Mul(a, b) ->
       let s1, t1 = infer env a in
       let s2, t2 = infer (apply_env s1 env) b in

--- a/src/lib/dict.ch
+++ b/src/lib/dict.ch
@@ -1,0 +1,31 @@
+# Dict Library
+# Native primitives: get, set, has, keys, values, merge, remove, entries, fromEntries
+
+# Church-encoded dict as association list (Option B)
+# A church_dict is a list of [key, value] pairs
+
+# Lookup in association list
+~assocGet alist,key (
+    matchList alist
+        (|>_. nil)
+        (|>pair. |>rest.
+            matchBool (eq (head pair) key)
+                (nth pair 1)
+                (assocGet rest key)))
+
+# Set in association list (replace or append)
+~assocSet alist,key,val (
+    cons [key, val] (filter (|>pair. not (eq (head pair) key)) alist))
+
+# Check if key exists
+~assocHas alist,key (
+    any (|>pair. eq (head pair) key) alist)
+
+# Get all keys
+~assocKeys alist (map (|>pair. head pair) alist)
+
+# Get all values
+~assocValues alist (map (|>pair. nth pair 1) alist)
+
+# Map over values
+~mapDict f,d (set d "placeholder" 0, fromEntries (map (|>pair. [head pair, f (nth pair 1)]) (entries d)))

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -24,6 +24,9 @@ type token =
   | Comma
   | LBracket
   | RBracket
+  | LBrace
+  | RBrace
+  | Colon
   | Pipe
   | Arrow
   | ColonColon
@@ -75,6 +78,10 @@ let tokenize s =
       aux (i+1) line (col+1) ((LBracket, line, col) :: acc)
     else if s.[i] = ']' then
       aux (i+1) line (col+1) ((RBracket, line, col) :: acc)
+    else if s.[i] = '{' then
+      aux (i+1) line (col+1) ((LBrace, line, col) :: acc)
+    else if s.[i] = '}' then
+      aux (i+1) line (col+1) ((RBrace, line, col) :: acc)
     else if s.[i] = '~' then
       aux (i+1) line (col+1) ((Tilde, line, col) :: acc)
     else if s.[i] = ',' then
@@ -85,6 +92,8 @@ let tokenize s =
       aux (i+1) line (col+1) ((Pipe, line, col) :: acc)
     else if i + 1 < String.length s && s.[i] = ':' && s.[i+1] = ':' then
       aux (i+2) line (col+2) ((ColonColon, line, col) :: acc)
+    else if s.[i] = ':' then
+      aux (i+1) line (col+1) ((Colon, line, col) :: acc)
     else if is_whitespace s.[i] then
       aux (i+1) line (col+1) acc
     else if s.[i] = '+' then
@@ -292,6 +301,7 @@ and parse_app tokens =
     | (Ident _, _, _) :: _
     | (LParen, _, _) :: _
     | (LBracket, _, _) :: _
+    | (LBrace, _, _) :: _
     | (String _, _, _) :: _ ->
         let arg, rest = parse_primary toks in
         aux (App (acc, arg)) rest
@@ -387,6 +397,29 @@ and parse_primary tokens =
       in
       let items, rest' = parse_list_items rest [] in
       (List items, rest')
+  | (LBrace, _, _) :: rest ->
+      let rec parse_dict_entries toks acc =
+        let toks = skip_newlines toks in
+        match toks with
+        | (RBrace, _, _) :: rest' -> (List.rev acc, rest')
+        | (Ident key, _, _) :: rest' | (String key, _, _) :: rest' ->
+            let rest' = skip_newlines rest' in
+            (match rest' with
+             | (Colon, _, _) :: rest'' ->
+                 let value, rest''' = parse_expr (skip_newlines rest'') in
+                 let rest''' = skip_newlines rest''' in
+                 (match rest''' with
+                  | (Comma, _, _) :: rest'''' -> parse_dict_entries rest'''' ((key, value) :: acc)
+                  | (RBrace, _, _) :: rest'''' -> (List.rev ((key, value) :: acc), rest'''')
+                  | (_, line, col) :: _ -> raise (ParseError ("Expected ',' or '}' in dict", line, col))
+                  | [] -> raise (ParseError ("Unterminated dict literal", 1, 1)))
+             | (_, line, col) :: _ -> raise (ParseError ("Expected ':' after dict key", line, col))
+             | [] -> raise (ParseError ("Expected ':' after dict key", 1, 1)))
+        | (_, line, col) :: _ -> raise (ParseError ("Expected key in dict", line, col))
+        | [] -> raise (ParseError ("Unterminated dict literal", 1, 1))
+      in
+      let entries, rest' = parse_dict_entries rest [] in
+      (Dict entries, rest')
   | (At, _, _) :: _ -> parse_var_def tokens
   | (tok, line, col) :: _ -> raise (ParseError ("Invalid expression", line, col))
   | [] -> raise (ParseError ("Invalid expression", 1, 1))
@@ -421,6 +454,7 @@ let string_of_typ t =
     | TVar v -> "'" ^ v
     | TFun (a, b) -> "(" ^ aux a ^ " -> " ^ aux b ^ ")"
     | TList a -> "[" ^ aux a ^ "]"
+    | TDict a -> "{String: " ^ aux a ^ "}"
     | TUnknown -> "?"
   in aux t
 

--- a/src/test/29_comparison.ch
+++ b/src/test/29_comparison.ch
@@ -1,0 +1,35 @@
+# Test comparison operators (#47)
+
+~(
+    # gt
+    assert (gt 5 3)
+    assert (not (gt 3 5))
+    assert (not (gt 3 3))
+    assert (gt 5.0 3.0)
+    assert (gt "b" "a")
+
+    # lt
+    assert (lt 3 5)
+    assert (not (lt 5 3))
+    assert (not (lt 3 3))
+    assert (lt 2.0 3.0)
+
+    # gte
+    assert (gte 5 3)
+    assert (gte 3 3)
+    assert (not (gte 2 3))
+
+    # lte
+    assert (lte 3 5)
+    assert (lte 3 3)
+    assert (not (lte 5 3))
+
+    # Mixed int/float
+    assert (gt 5 3.0)
+    assert (lt 2.0 5)
+
+    # Use in filter
+    @nums [1, 2, 3, 4, 5]
+    assert (eq (filter (|>x. gt x 3) nums) [4, 5])
+    assert (eq (filter (|>x. lte x 2) nums) [1, 2])
+)

--- a/src/test/30_string_interpolation.ch
+++ b/src/test/30_string_interpolation.ch
@@ -1,0 +1,20 @@
+# Test string interpolation helpers (#48)
+
+~(
+    # str: concatenate list of values into string
+    @name "Alice"
+    @age 30
+    assert (eq (str ["Hello ", name, ", age ", age]) "Hello Alice, age 30")
+    assert (eq (str [1, " + ", 2, " = ", 3]) "1 + 2 = 3")
+    assert (eq (str []) "")
+
+    # join: join list with separator
+    assert (eq (join ", " ["a", "b", "c"]) "a, b, c")
+    assert (eq (join " " [1, 2, 3]) "1 2 3")
+    assert (eq (join "-" []) "")
+
+    # Practical: build a response
+    @user "Bob"
+    @score 95
+    assert (eq (str [user, " scored ", score, "%"]) "Bob scored 95%")
+)

--- a/src/test/31_dict.ch
+++ b/src/test/31_dict.ch
@@ -1,0 +1,54 @@
+# Test dictionary/map type (#49) — both approaches
+
+# Option A: Native dict with {} syntax
+@user {name: "Alice", age: 30, active: true}
+
+~(
+    # get
+    assert (eq (get user "name") "Alice")
+    assert (eq (get user "age") 30)
+
+    # set (returns new dict)
+    @updated (set user "age" 31)
+    assert (eq (get updated "age") 31)
+    assert (eq (get user "age") 30)
+
+    # has
+    assert (has user "name")
+    assert (not (has user "email"))
+
+    # keys / values
+    assert (eq (len (keys user)) 3)
+    assert (eq (len (values user)) 3)
+
+    # merge
+    @extra {email: "alice@test.com", role: "admin"}
+    @merged (merge user extra)
+    assert (has merged "email")
+    assert (has merged "name")
+
+    # remove
+    @smaller (remove user "active")
+    assert (not (has smaller "active"))
+    assert (has smaller "name")
+
+    # entries / fromEntries roundtrip
+    @pairs (entries user)
+    @rebuilt (fromEntries pairs)
+    assert (eq (get rebuilt "name") "Alice")
+
+    # Empty dict
+    @empty {}
+    assert (eq (len (keys empty)) 0)
+
+    # Error handling
+    @result (try (get user "missing") (|>e. "caught"))
+    assert (eq result "caught")
+
+    # Option B: Church-encoded dict (association list)
+    @church_user [["name", "Alice"], ["age", 30]]
+    assert (eq (assocGet church_user "name") "Alice")
+    assert (assocHas church_user "name")
+    assert (not (assocHas church_user "email"))
+    assert (eq (assocKeys church_user) ["name", "age"])
+)

--- a/src/test/32_json.ch
+++ b/src/test/32_json.ch
@@ -1,0 +1,57 @@
+# Test JSON parsing and generation (#50)
+
+~(
+    # toJson — primitives
+    assert (eq (toJson 42) "42")
+    assert (eq (toJson "hello") "\"hello\"")
+    assert (eq (toJson true) "true")
+    assert (eq (toJson false) "false")
+    assert (eq (toJson nil) "null")
+
+    # toJson — list
+    assert (eq (toJson [1, 2, 3]) "[1,2,3]")
+
+    # toJson — dict
+    @data {name: "Alice", age: 30}
+    @json (toJson data)
+    assert (contains json "\"name\":\"Alice\"")
+    assert (contains json "\"age\":30")
+
+    # toJson — nested
+    @nested {users: [{name: "Bob"}, {name: "Eve"}], count: 2}
+    @json2 (toJson nested)
+    assert (contains json2 "\"users\"")
+    assert (contains json2 "\"Bob\"")
+
+    # fromJson — primitives
+    assert (eq (fromJson "42") 42)
+    assert (eq (fromJson "3.14") 3.14)
+    assert (eq (fromJson "\"hello\"") "hello")
+    assert (eq (fromJson "true") true)
+    assert (eq (fromJson "false") false)
+    assert (eq (fromJson "null") nil)
+
+    # fromJson — array
+    @arr (fromJson "[1, 2, 3]")
+    assert (eq arr [1, 2, 3])
+
+    # fromJson — object
+    @obj (fromJson "{\"x\": 1, \"y\": 2}")
+    assert (eq (get obj "x") 1)
+    assert (eq (get obj "y") 2)
+
+    # fromJson — nested
+    @deep (fromJson "{\"data\": [1, 2], \"ok\": true}")
+    assert (eq (get deep "data") [1, 2])
+    assert (eq (get deep "ok") true)
+
+    # Roundtrip: toJson → fromJson
+    @original {name: "test", scores: [90, 85]}
+    @roundtrip (fromJson (toJson original))
+    assert (eq (get roundtrip "name") "test")
+    assert (eq (get roundtrip "scores") [90, 85])
+
+    # Error handling
+    @bad (try (fromJson "invalid") (|>e. "parse error"))
+    assert (eq bad "parse error")
+)

--- a/src/types.ml
+++ b/src/types.ml
@@ -7,6 +7,7 @@ type typ =
   | TVar of string
   | TFun of typ * typ
   | TList of typ
+  | TDict of typ
   | TUnknown
 
 type scheme = Forall of string list * typ
@@ -19,6 +20,7 @@ let free_type_vars_typ t =
     | TVar v -> if List.mem v acc then acc else v :: acc
     | TFun (a, b) -> aux (aux acc a) b
     | TList a -> aux acc a
+    | TDict a -> aux acc a
     | _ -> acc
   in aux [] t
 
@@ -43,5 +45,6 @@ let instantiate (Forall (vars, t)) =
     | TVar v as tv -> (try List.assoc v subst with Not_found -> tv)
     | TFun (a, b) -> TFun (subst_typ a, subst_typ b)
     | TList a -> TList (subst_typ a)
+    | TDict a -> TDict (subst_typ a)
     | t -> t
   in subst_typ t


### PR DESCRIPTION
## Summary

### #47 — Comparison operators
`gt`, `lt`, `gte`, `lte` — curried, work on numeric and string values.
```
filter (|>x. gt x 3) [1, 2, 3, 4, 5]   # [4, 5]
```

### #48 — String interpolation
`str` (list→string) and `join` (separator→list→string):
```
str ["Hello ", name, ", age ", age]   # "Hello Alice, age 30"
join ", " ["a", "b", "c"]            # "a, b, c"
```

### #49 — Dictionary type (both approaches)
**Option A — Native:** `{key: value}` syntax with `VDict`/`TDict`:
```
@user {name: "Alice", age: 30}
get user "name"   # "Alice"
```
**Option B — Church-encoded:** association list helpers in `dict.ch`:
```
@user [["name", "Alice"], ["age", 30]]
assocGet user "name"   # "Alice"
```

### #50 — JSON parsing/generation
`toJson` (value→string) and `fromJson` (string→value):
```
toJson {name: "Alice", scores: [90, 85]}
# '{"name":"Alice","scores":[90,85]}'

@obj (fromJson "{\"x\": 1}")
get obj "x"   # 1
```

Closes #47, closes #48, closes #49, closes #50

## Test plan
- [x] All 41 OCaml unit tests pass
- [x] All 32 integration tests pass (4 new: comparison, string interpolation, dict, json)