### PR TITLE
fix: tree-shake stdlib in native compile (#110) + interpreter-parity roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 A functional programming language named after Alonzo Church and Alan Turing, implemented in OCaml.
 
+> **Native compile work:** the current active effort is bringing `churing compile` (LLVM →
+> native binary) to full interpreter parity. The canonical resume doc — current state, the
+> ordered issue plan, and the keystone blocker (#117) — is **`docs/native-compile-roadmap.md`**.
+> Read it first when resuming this work, and update it (plus sync GitHub issues) after every step.
+
 ## Project Structure
 
 - `src/churing.ml` — Entry point: parse → type-infer → evaluate

--- a/docs/native-compile-roadmap.md
+++ b/docs/native-compile-roadmap.md
@@ -1,0 +1,82 @@
+# Native Compile Roadmap — path to full interpreter parity
+
+> Canonical resume doc for the `churing compile` (LLVM → native binary) work.
+> Goal: native compilation reaches **full feature parity with the interpreter**.
+> Working rule: after **every** step, update this doc AND sync GitHub issues
+> (close done / comment partial / create new gaps). Don't batch to session end.
+
+_Last verified: 2026-06-06._
+
+## How native compile works
+- Triggered **only** by the `compile` subcommand: `churing compile <file> -o <out>`.
+  The `--native` flag is silently ignored (runs the interpreter).
+- Pipeline: `Parser.parse_and_infer` → `Codegen.compile_to_binary` → LLVM IR → object →
+  link with the Rust runtime staticlib (`src/rust/native/`) → native ELF.
+- Tests live in `src/test/native/*.ch` (compiled + run). The numbered `src/test/*.ch` tests
+  run the **interpreter** only.
+
+## Current state
+- Interpreter: healthy (31 unit incl. 16 codegen, ~50 integration pass).
+- Native tests: **5/5 PASS** — 01_arithmetic, 02_logic, 03_print, 04_stdlib, 05_strings.
+- Last change: tree-shaking in `compile_to_binary` (commit `efd3275`, branch
+  `fix/treeshake-stdlib-native-compile`, **not pushed**) — only stdlib FunDefs transitively
+  reachable from the user program are compiled (reachability over `free_vars`), so the
+  still-broken ML stdlib isn't dragged into trivial programs. Also made `free_vars`
+  exhaustive (was empty for Assert/FunDef/Dict/Try/Import).
+
+## How to test
+Docker image `churing-test` is built. The full `run-tests.sh` aborts at the broken
+`59_native_file_io.ch` (stack overflow, interpreter mode, `set -e`) before the native
+section — pre-existing, unrelated. Run the native section directly:
+```bash
+docker run --rm --user root -e OPAMROOTISOK=1 -v "$(pwd):/app" churing-test bash -c '
+  eval "$(opam env)"; dune build src/churing.exe
+  for f in src/test/native/*.ch; do case "$f" in *.out) continue;; esac
+    n=$(basename "$f" .ch); ./_build/default/src/churing.exe compile "$f" -o /tmp/$n && /tmp/$n; done'
+```
+
+## The keystone blocker: #117
+The type pre-pass in `compile_module` (`src/codegen.ml` ~964–1062) is only a binary
+`ptr`-vs-`f64` classifier. It mistypes lists/dicts and can't express polymorphism (e.g.
+`foldl` over both scalar and dict accumulators → conflicting monomorphic signatures).
+**Agreed fix:** thread `infer.ml` Hindley-Milner types into codegen
+(`TList`/`TDict`/`TFun` → ptr, `TInt`/`TFloat` → f64/i64) to REPLACE the fixpoint, PLUS
+per-call-site monomorphization. Unblocks the entire ML stack (vector/matrix/activations/
+loss/nn) and #106.
+
+## Ordered implementation plan (start at the top)
+
+### Phase 1 — independent quick wins
+Pattern: add a Rust runtime fn in `src/rust/native/src/runtime.rs` + a codegen App-dispatch
+case (same shape as the already-done #111). No dependency on the hard typing work.
+1. **#105** Try/catch in codegen (self-contained; `codegen.ml:905` currently `failwith`)
+2. **#113** time primitives (`now`/`timeMs`/`year`/…)
+3. **#114** JSON primitives (`toJson`/`fromJson`)
+4. **#112** finish file I/O — `readLines`/`writeLines` (other 5 done)
+5. **#104** dict ops — `keys`/`values`/`merge`/`entries`/`fromEntries` (get/set/has/remove + literals done)
+
+### Phase 2 — string-list foundation
+6. **#115** polymorphic cons cells (ptr-headed lists) — keystone for strings/heterogeneous lists
+7. **#102** `split`/`join` (needs #115; indexOf/charAt done)
+8. **#116** `str` mixed-type expansion (needs #115)
+9. **#118** advanced match patterns — string/list-literal + nested cons sub-patterns
+   (`codegen.ml:801/807/813` `failwith`; string patterns need #115)
+
+### Phase 3 — keystone (long pole; can run parallel to Phase 1)
+10. **#117** HM types → codegen + monomorphization (see above)
+
+### Phase 4 — integration & capstone
+11. **#110** load full stdlib + `Import` (completable once #115/#117 + per-prim issues land)
+12. **#119** MySQL native (needs #115 + #104; optional, biggest external dep)
+13. **#106** end-to-end native digits training/prediction (needs #117, #112, #104, #102, #114)
+14. **#108** benchmark native vs interpreter vs Python/PyTorch (after #106)
+
+## Issue triage
+- **Relevant (parity):** #117, #115, #116, #118, #102, #104, #105, #112, #113, #114, #110, #119, #106, #108
+- **Deferred tracks** (after the compiler; not parity): ML/tensor/GPU #97, #98, #75, #78, #79, #107;
+  web #80–#84; AWS #85–#88; speculative #99 (`ask`/LLM).
+- **Closed done (2026-06-06):** #100, #101, #103, #109, #111.
+- **Created (2026-06-06):** #118 (match patterns), #119 (mysql native).
+- **Arrays** (`arrayCreate`/`Get`/`Set`/`Length`/`FromList`/`ToList`): intentionally **no
+  issue** — legacy, superseded by tensors (#97); candidate to delete from the interpreter
+  (won't-fix in native). **Decision pending with the user.**

--- a/docs/native-compile-roadmap.md
+++ b/docs/native-compile-roadmap.md
@@ -19,7 +19,7 @@ _Last verified: 2026-06-06._
 - Interpreter: healthy (31 unit incl. 16 codegen, ~50 integration pass).
 - Native tests: **5/5 PASS** — 01_arithmetic, 02_logic, 03_print, 04_stdlib, 05_strings.
 - Last change: tree-shaking in `compile_to_binary` (commit `efd3275`, branch
-  `fix/treeshake-stdlib-native-compile`, **not pushed**) — only stdlib FunDefs transitively
+  `fix/treeshake-stdlib-native-compile`, pushed — **PR #120** open against master) — only stdlib FunDefs transitively
   reachable from the user program are compiled (reachability over `free_vars`), so the
   still-broken ML stdlib isn't dragged into trivial programs. Also made `free_vars`
   exhaustive (was empty for Assert/FunDef/Dict/Try/Import).

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -40,6 +40,7 @@ let fresh_lam () =
 
 (* Primitive names handled inline in the App case — not in known_fns or env *)
 let inline_primitives = StringSet.of_list [
+  "if";
   "cons"; "head"; "tail"; "empty";
   "gt"; "lt"; "gte"; "lte"; "not"; "and"; "or";
   "print";
@@ -488,6 +489,26 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
            let p = ptr_ty ctx in
            let ft = Llvm.function_type f64 [| p |] in
            Llvm.build_call ft (declare_ext md "churing_to_float" ft) [| sv |] "tofloat" builder
+       (* ── if cond then_val else_val ── *)
+       | Some ("if", [cond_e; then_e; else_e]) ->
+           let cond_v = compile_expr ctx md builder known_fns env false cond_e in
+           let zero = Llvm.const_float f64 0.0 in
+           let cmp = Llvm.build_fcmp Llvm.Fcmp.One cond_v zero "if_cond" builder in
+           let fn = Llvm.block_parent (Llvm.insertion_block builder) in
+           let then_bb  = Llvm.append_block ctx "if_then"  fn in
+           let else_bb  = Llvm.append_block ctx "if_else"  fn in
+           let merge_bb = Llvm.append_block ctx "if_merge" fn in
+           ignore (Llvm.build_cond_br cmp then_bb else_bb builder);
+           Llvm.position_at_end then_bb builder;
+           let then_v = compile_expr ctx md builder known_fns env in_tail then_e in
+           let then_end = Llvm.insertion_block builder in
+           ignore (Llvm.build_br merge_bb builder);
+           Llvm.position_at_end else_bb builder;
+           let else_v = compile_expr ctx md builder known_fns env in_tail else_e in
+           let else_end = Llvm.insertion_block builder in
+           ignore (Llvm.build_br merge_bb builder);
+           Llvm.position_at_end merge_bb builder;
+           Llvm.build_phi [(then_v, then_end); (else_v, else_end)] "if_r" builder
        (* ── Known function direct call ── *)
        | Some (name, args) ->
            (match Hashtbl.find_opt known_fns name with

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -47,7 +47,9 @@ let inline_primitives = StringSet.of_list [
   "length"; "concat"; "substring"; "uppercase"; "lowercase"; "trim";
   "contains"; "startsWith"; "endsWith"; "replace"; "toFloat";
   "indexOf"; "charAt";
+  "random"; "toInt";
   "get"; "set"; "has";
+  "matchList"; "matchBool";
 ]
 
 (* Variables bound by a pattern *)
@@ -189,7 +191,17 @@ let rec arg_is_list_in_body arg_name = function
       arg_is_list_in_body arg_name e ||
       List.exists (fun (_, b) -> arg_is_list_in_body arg_name b) arms
   | Seq (a, b) -> arg_is_list_in_body arg_name a || arg_is_list_in_body arg_name b
-  | App (f, a) -> arg_is_list_in_body arg_name f || arg_is_list_in_body arg_name a
+  | App _ as full_app ->
+      (* matchList arg ... ⟹ arg is a list *)
+      (match flatten_app [] full_app with
+       | Some ("matchList", Var x :: _) when x = arg_name -> true
+       | Some (_, args) ->
+           List.exists (arg_is_list_in_body arg_name) args
+       | None ->
+           (match full_app with
+            | App (f, a) ->
+                arg_is_list_in_body arg_name f || arg_is_list_in_body arg_name a
+            | _ -> false))
   | Lam (x, body) when x <> arg_name -> arg_is_list_in_body arg_name body
   | Let (_, v) -> arg_is_list_in_body arg_name v
   | _ -> false
@@ -229,6 +241,7 @@ let rec body_returns_list_v list_fns list_vars is_list_arg = function
   | App (f, _) ->
       (match flatten_app [] f with
        | Some ("cons", _) -> true
+       | Some ("matchList", _) -> true
        | Some (name, _) -> StringSet.mem name list_fns
        | None -> false)
   | _ -> false
@@ -495,6 +508,14 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
            let p = ptr_ty ctx in
            let ft = Llvm.function_type p [| f64 |] in
            Llvm.build_call ft (declare_ext md "churing_to_string" ft) [| nv |] "tostr" builder
+       | Some ("random", [arg_e]) ->
+           let av = compile_expr ctx md builder known_fns env false arg_e in
+           let ft = Llvm.function_type f64 [| f64 |] in
+           Llvm.build_call ft (declare_ext md "churing_random" ft) [| av |] "rnd" builder
+       | Some ("toInt", [arg_e]) ->
+           let av = compile_expr ctx md builder known_fns env false arg_e in
+           let ft = Llvm.function_type f64 [| f64 |] in
+           Llvm.build_call ft (declare_ext md "churing_to_int" ft) [| av |] "toint" builder
        | Some ("toFloat", [s_expr]) ->
            let sv = compile_expr ctx md builder known_fns env false s_expr in
            let p = ptr_ty ctx in
@@ -540,6 +561,59 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
            let p = ptr_ty ctx in
            let ft = Llvm.function_type p [| p; f64 |] in
            Llvm.build_call ft (declare_ext md "churing_char_at" ft) [| sv; iv |] "charat" builder
+       (* ── matchBool: lazy if-then-else (Scott-encoded boolean) ── *)
+       | Some ("matchBool", [cond_e; then_e; else_e]) ->
+           let cond_v = compile_expr ctx md builder known_fns env false cond_e in
+           let cond_v = auto_unbox_f64 ctx builder cond_v in
+           let zero = Llvm.const_float f64 0.0 in
+           let cmp = Llvm.build_fcmp Llvm.Fcmp.One cond_v zero "mb_cond" builder in
+           let fn = Llvm.block_parent (Llvm.insertion_block builder) in
+           let then_bb  = Llvm.append_block ctx "mb_then"  fn in
+           let else_bb  = Llvm.append_block ctx "mb_else"  fn in
+           let merge_bb = Llvm.append_block ctx "mb_merge" fn in
+           ignore (Llvm.build_cond_br cmp then_bb else_bb builder);
+           Llvm.position_at_end then_bb builder;
+           let then_v = compile_expr ctx md builder known_fns env in_tail then_e in
+           let then_end = Llvm.insertion_block builder in
+           ignore (Llvm.build_br merge_bb builder);
+           Llvm.position_at_end else_bb builder;
+           let else_v = compile_expr ctx md builder known_fns env in_tail else_e in
+           let else_end = Llvm.insertion_block builder in
+           ignore (Llvm.build_br merge_bb builder);
+           Llvm.position_at_end merge_bb builder;
+           Llvm.build_phi [(then_v, then_end); (else_v, else_end)] "mb_r" builder
+       (* ── matchList: pattern match on list (Church-style eliminator) ── *)
+       | Some ("matchList", [lst_e; nil_fn_e; cons_fn_e]) ->
+           let lst_v    = compile_expr ctx md builder known_fns env false lst_e in
+           let nil_fn_v = compile_expr ctx md builder known_fns env false nil_fn_e in
+           let cons_fn_v= compile_expr ctx md builder known_fns env false cons_fn_e in
+           (* Return type: infer from nil_fn body (e.g. Lam("_", List[]) → ptr) *)
+           let ret_is_ptr = match nil_fn_e with
+             | Lam (_, body) -> body_returns_list StringSet.empty body
+             | _ -> false
+           in
+           let ret_ty = if ret_is_ptr then p else f64 in
+           let fn = Llvm.block_parent (Llvm.insertion_block builder) in
+           let nil_bb  = Llvm.append_block ctx "ml_nil"  fn in
+           let cons_bb = Llvm.append_block ctx "ml_cons" fn in
+           let end_bb  = Llvm.append_block ctx "ml_end"  fn in
+           let null_ptr = Llvm.const_null p in
+           let is_nil = Llvm.build_icmp Llvm.Icmp.Eq lst_v null_ptr "is_nil" builder in
+           ignore (Llvm.build_cond_br is_nil nil_bb cons_bb builder);
+           Llvm.position_at_end nil_bb builder;
+           let dummy = Llvm.const_float f64 0.0 in
+           let nil_result = call_closure ctx builder nil_fn_v dummy ret_ty in
+           let nil_pred = Llvm.insertion_block builder in
+           ignore (Llvm.build_br end_bb builder);
+           Llvm.position_at_end cons_bb builder;
+           let head_v = build_list_head ctx builder lst_v in
+           let tail_v = build_list_tail ctx builder lst_v in
+           let partial = call_closure ctx builder cons_fn_v head_v p in
+           let cons_result = call_closure ctx builder partial tail_v ret_ty in
+           let cons_pred = Llvm.insertion_block builder in
+           ignore (Llvm.build_br end_bb builder);
+           Llvm.position_at_end end_bb builder;
+           Llvm.build_phi [(nil_result, nil_pred); (cons_result, cons_pred)] "ml_r" builder
        (* ── if cond then_val else_val ── *)
        | Some ("if", [cond_e; then_e; else_e]) ->
            let cond_v = compile_expr ctx md builder known_fns env false cond_e in
@@ -689,6 +763,10 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
   | Seq (Let (name, ve), rest) ->
       let v = compile_expr ctx md builder known_fns env false ve in
       compile_expr ctx md builder known_fns (StringMap.add name v env) in_tail rest
+  | Seq (FunDef (name, args, body), rest) ->
+      (* Nested function definition — compile it and add to known_fns for the rest *)
+      ignore (compile_fundef ctx md known_fns name args body);
+      compile_expr ctx md builder known_fns env in_tail rest
   | Seq (a, b) ->
       ignore (compile_expr ctx md builder known_fns env false a);
       compile_expr ctx md builder known_fns env in_tail b
@@ -777,8 +855,9 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
 (* Compile a named function body into its pre-declared (or freshly declared) LLVM function.
    When called from compile_module, the function is already in known_fns (from the pre-pass)
    and has a mangled LLVM name to prevent libc symbol conflicts.
-   When called from the JIT path, known_fns is empty and we define a fresh function. *)
-let compile_fundef ctx md known_fns name args body =
+   When called from the JIT path, known_fns is empty and we define a fresh function.
+   Mutually recursive with compile_expr (nested ~defs inside function bodies). *)
+and compile_fundef ctx md known_fns name args body =
   let f64 = Llvm.double_type ctx in
   let p = ptr_ty ctx in
   let fn, ft = match Hashtbl.find_opt known_fns name with
@@ -1000,7 +1079,17 @@ let find_runtime_lib () =
 
 let compile_to_binary ?(output="a.out") exprs =
   ensure_initialized ();
-  let stdlib = load_stdlib_fundefs "math.ch" @ load_stdlib_fundefs "prelude.ch" in
+  let stdlib =
+    load_stdlib_fundefs "math.ch"       @
+    load_stdlib_fundefs "prelude.ch"    @
+    load_stdlib_fundefs "operators.ch"  @
+    load_stdlib_fundefs "list.ch"       @
+    load_stdlib_fundefs "vector.ch"     @
+    load_stdlib_fundefs "matrix.ch"     @
+    load_stdlib_fundefs "activations.ch" @
+    load_stdlib_fundefs "loss.ch"       @
+    load_stdlib_fundefs "nn.ch"
+  in
   let all_exprs = stdlib @ exprs in
   let (ctx, md, known_fns) = compile_module all_exprs in
   let non_fundefs = List.filter (function FunDef _ -> false | _ -> true) exprs in

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -50,6 +50,8 @@ let inline_primitives = StringSet.of_list [
   "random"; "toInt";
   "get"; "set"; "has";
   "matchList"; "matchBool";
+  "env"; "envOr";
+  "toString"; "str";
 ]
 
 (* Variables bound by a pattern *)
@@ -429,12 +431,14 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
            let printf_fn = match Llvm.lookup_function "printf" md with
              | Some f -> f
              | None -> Llvm.declare_function "printf" printf_ft md in
-           let fmt_str = "%g\n\x00" in
+           let is_ptr = Llvm.classify_type (Llvm.type_of v) = Llvm.TypeKind.Pointer in
+           let fmt_str = if is_ptr then "%s\n\x00" else "%g\n\x00" in
+           let fmt_key = if is_ptr then ".fmt_s" else ".fmt_g" in
            let fmt_const = Llvm.const_string ctx fmt_str in
-           let fmt_global = match Llvm.lookup_global ".fmt_g" md with
+           let fmt_global = match Llvm.lookup_global fmt_key md with
              | Some g -> g
              | None ->
-                 let g = Llvm.define_global ".fmt_g" fmt_const md in
+                 let g = Llvm.define_global fmt_key fmt_const md in
                  Llvm.set_linkage Llvm.Linkage.Private g;
                  Llvm.set_global_constant true g;
                  g in
@@ -444,6 +448,18 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
              "fmt" builder in
            ignore (Llvm.build_call printf_ft printf_fn [| fmt_ptr; v |] "" builder);
            v
+       (* ── env / envOr ── *)
+       | Some ("env", [name_expr]) ->
+           let nv = compile_expr ctx md builder known_fns env false name_expr in
+           let p = ptr_ty ctx in
+           let ft = Llvm.function_type p [| p |] in
+           Llvm.build_call ft (declare_ext md "churing_env" ft) [| nv |] "env" builder
+       | Some ("envOr", [name_expr; default_expr]) ->
+           let nv = compile_expr ctx md builder known_fns env false name_expr in
+           let dv = compile_expr ctx md builder known_fns env false default_expr in
+           let p = ptr_ty ctx in
+           let ft = Llvm.function_type p [| p; p |] in
+           Llvm.build_call ft (declare_ext md "churing_env_or" ft) [| nv; dv |] "envOr" builder
        (* ── String operations ── *)
        | Some ("length", [s_expr]) ->
            let sv = compile_expr ctx md builder known_fns env false s_expr in

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -249,6 +249,7 @@ let declare_ext md name ft =
 let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llvalue) Hashtbl.t) env in_tail = function
   | Int n   -> Llvm.const_float (Llvm.double_type ctx) (float_of_int n)
   | Float f -> Llvm.const_float (Llvm.double_type ctx) f
+  | Lng n   -> Llvm.const_float (Llvm.double_type ctx) (Int64.to_float n)
   | Bool b  -> Llvm.const_float (Llvm.double_type ctx) (if b then 1.0 else 0.0)
 
   | Str s ->

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -38,6 +38,15 @@ let fresh_lam () =
   incr lam_counter;
   Printf.sprintf "_lam_%d" n
 
+(* Primitive names handled inline in the App case — not in known_fns or env *)
+let inline_primitives = StringSet.of_list [
+  "cons"; "head"; "tail"; "empty";
+  "gt"; "lt"; "gte"; "lte"; "not"; "and"; "or";
+  "print";
+  "length"; "concat"; "substring"; "uppercase"; "lowercase"; "trim";
+  "contains"; "startsWith"; "endsWith"; "replace"; "toFloat";
+]
+
 (* Variables bound by a pattern *)
 let rec pattern_vars = function
   | PVar x -> StringSet.singleton x
@@ -116,24 +125,38 @@ let build_list_tail ctx builder cell =
   let gep = Llvm.build_gep cell_ty cell [| z; Llvm.const_int i32 1 |] "tgep" builder in
   Llvm.build_load p gep "tail" builder
 
-(* Build a closure struct value {fn_ptr, env_ptr} without heap allocation *)
-let build_closure ctx builder fn env_ptr =
+(* Heap-allocate a closure {fn_ptr, env_ptr} and return a ptr to it *)
+let build_closure ctx md builder fn env_ptr =
+  let p = ptr_ty ctx in
   let clos_t = closure_ty ctx in
-  let p = ptr_ty ctx in
+  let gc_malloc = get_gc_malloc ctx md in
+  let gc_malloc_ft = Llvm.function_type p [| Llvm.i64_type ctx |] in
+  let size = Llvm.const_int (Llvm.i64_type ctx) 16 in
+  let clos_ptr = Llvm.build_call gc_malloc_ft gc_malloc [| size |] "clos_p" builder in
+  let i32 = Llvm.i32_type ctx in
+  let z = Llvm.const_int i32 0 in
   let fn_p = Llvm.build_bitcast fn p "fn_p" builder in
-  let c0 = Llvm.build_insertvalue (Llvm.undef clos_t) fn_p 0 "c0" builder in
-  Llvm.build_insertvalue c0 env_ptr 1 "clos" builder
+  let fgep = Llvm.build_gep clos_t clos_ptr [| z; Llvm.const_int i32 0 |] "fgep" builder in
+  ignore (Llvm.build_store fn_p fgep builder);
+  let egep = Llvm.build_gep clos_t clos_ptr [| z; Llvm.const_int i32 1 |] "egep" builder in
+  ignore (Llvm.build_store env_ptr egep builder);
+  clos_ptr
 
-(* Call a closure value: extract fn_ptr and env_ptr, call fn_ptr(arg, env_ptr) *)
-let call_closure ctx builder clos_val arg_val =
-  let f64 = Llvm.double_type ctx in
+(* Call a closure ptr: load {fn_ptr, env_ptr}, call fn_ptr(arg, env_ptr) with given ret_ty *)
+let call_closure ctx builder clos_ptr arg_val ret_ty =
   let p = ptr_ty ctx in
-  let fn_ptr  = Llvm.build_extractvalue clos_val 0 "fn_ptr"  builder in
-  let env_ptr = Llvm.build_extractvalue clos_val 1 "env_ptr" builder in
-  let ft = Llvm.function_type f64 [| f64; p |] in
+  let clos_t = closure_ty ctx in
+  let i32 = Llvm.i32_type ctx in
+  let z = Llvm.const_int i32 0 in
+  let fn_gep  = Llvm.build_gep clos_t clos_ptr [| z; Llvm.const_int i32 0 |] "fn_gep"  builder in
+  let env_gep = Llvm.build_gep clos_t clos_ptr [| z; Llvm.const_int i32 1 |] "env_gep" builder in
+  let fn_ptr  = Llvm.build_load p fn_gep  "fn_ptr"  builder in
+  let env_ptr = Llvm.build_load p env_gep "env_ptr" builder in
+  let arg_ty  = Llvm.type_of arg_val in
+  let ft = Llvm.function_type ret_ty [| arg_ty; p |] in
   Llvm.build_call ft fn_ptr [| arg_val; env_ptr |] "app" builder
 
-(* Wrap a 1-arg f64→f64 named function as a closure *)
+(* Wrap a 1-arg f64→f64 named function as a heap-allocated closure ptr *)
 let wrap_fn_as_closure ctx md builder fn name =
   let f64 = Llvm.double_type ctx in
   let p = ptr_ty ctx in
@@ -150,7 +173,7 @@ let wrap_fn_as_closure ctx md builder fn name =
         ignore (Llvm.build_ret r wb);
         wfn
   in
-  build_closure ctx builder wfn (Llvm.const_null p)
+  build_closure ctx md builder wfn (Llvm.const_null p)
 
 (* ── Static type analysis for pre-pass ─────────────────────────────────────── *)
 
@@ -168,6 +191,19 @@ let rec arg_is_list_in_body arg_name = function
   | Let (_, v) -> arg_is_list_in_body arg_name v
   | _ -> false
 
+(* Check if arg_name appears in direct function-call position, indicating a closure arg *)
+let rec arg_is_closure_in_body arg_name = function
+  | App (Var f, _) when f = arg_name -> true
+  | App (f, a) ->
+      arg_is_closure_in_body arg_name f || arg_is_closure_in_body arg_name a
+  | Match (e, arms) ->
+      arg_is_closure_in_body arg_name e ||
+      List.exists (fun (_, b) -> arg_is_closure_in_body arg_name b) arms
+  | Seq (a, b) -> arg_is_closure_in_body arg_name a || arg_is_closure_in_body arg_name b
+  | Lam (x, body) when x <> arg_name -> arg_is_closure_in_body arg_name body
+  | Let (_, v) -> arg_is_closure_in_body arg_name v
+  | _ -> false
+
 (* Vars introduced as list by a cons pattern's tail binding *)
 let rec cons_tail_vars = function
   | PCons (_, PVar t) -> StringSet.singleton t
@@ -180,6 +216,7 @@ let rec cons_tail_vars = function
    is_list_arg: test if a var name is a list-typed argument. *)
 let rec body_returns_list_v list_fns list_vars is_list_arg = function
   | List _ -> true
+  | Lam _ -> true  (* lambdas are heap-allocated — return ptr *)
   | Var x -> StringSet.mem x list_vars || StringSet.mem x list_fns || is_list_arg x
   | Match (_, arms) ->
       List.exists (fun (pat, body) ->
@@ -248,47 +285,62 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
   | Lam (x, body) ->
       let f64 = Llvm.double_type ctx in
       let p = ptr_ty ctx in
-      let top = Hashtbl.fold (fun n _ s -> StringSet.add n s) known_fns StringSet.empty in
+      let i8 = Llvm.i8_type ctx in
+      let top = Hashtbl.fold (fun n _ s -> StringSet.add n s) known_fns inline_primitives in
       let fv_set = free_vars (StringSet.add x top) body in
       let fv = StringSet.elements fv_set in
+      (* Captured values with their types *)
+      let fv_caps = List.map (fun name ->
+        match StringMap.find_opt name env with
+        | Some v -> (name, v)
+        | None -> failwith (Printf.sprintf "codegen: lambda captures unbound variable '%s'" name)
+      ) fv in
       let lam_name = fresh_lam () in
-      let lft = Llvm.function_type f64 [| f64; p |] in
+      (* Determine arg and return types from static analysis *)
+      let arg_is_ptr = arg_is_list_in_body x body || arg_is_closure_in_body x body in
+      let ret_is_ptr = body_returns_list StringSet.empty body in
+      let arg_ty = if arg_is_ptr then p else f64 in
+      let ret_ty = if ret_is_ptr then p else f64 in
+      let lft = Llvm.function_type ret_ty [| arg_ty; p |] in
       let lam_fn = Llvm.define_function lam_name lft md in
       let lbb = Llvm.entry_block lam_fn in
       let lb  = Llvm.builder_at_end ctx lbb in
       Llvm.set_value_name x (Llvm.params lam_fn).(0);
       let env_param = (Llvm.params lam_fn).(1) in
+      (* Unpack env: byte-level GEP so mixed f64/ptr slots are handled correctly *)
       let lam_env =
-        List.fold_left (fun acc (i, name) ->
-          let idx = Llvm.const_int (Llvm.i64_type ctx) i in
-          let ep  = Llvm.build_gep f64 env_param [| idx |] ("ep_" ^ name) lb in
-          let v   = Llvm.build_load f64 ep name lb in
+        List.fold_left (fun acc (i, (name, cap_val)) ->
+          let slot_ty = Llvm.type_of cap_val in
+          let byte_off = Llvm.const_int (Llvm.i64_type ctx) (i * 8) in
+          let ep = Llvm.build_gep i8 env_param [| byte_off |] ("ep_" ^ name) lb in
+          let v  = Llvm.build_load slot_ty ep name lb in
           StringMap.add name v acc)
         (StringMap.singleton x (Llvm.params lam_fn).(0))
-        (List.mapi (fun i n -> (i, n)) fv)
+        (List.mapi (fun i nc -> (i, nc)) fv_caps)
       in
       let result = compile_expr ctx md lb known_fns lam_env true body in
-      (if Llvm.classify_type (Llvm.type_of result) <> Llvm.TypeKind.Double then
-        failwith "codegen: lambda body must return f64 (list-returning lambdas deferred to #95)");
       ignore (Llvm.build_ret result lb);
+      (* Pack env: byte-level GEP, store each captured value with its actual type *)
       let env_ptr =
         if fv = [] then Llvm.const_null p
         else begin
-          let n    = List.length fv in
+          let n    = List.length fv_caps in
           let size = Llvm.const_int (Llvm.i64_type ctx) (n * 8) in
           let mfn  = get_gc_malloc ctx md in
           let mft  = Llvm.function_type p [| Llvm.i64_type ctx |] in
           let ep   = Llvm.build_call mft mfn [| size |] "env_p" builder in
-          List.iteri (fun i name ->
-            let idx  = Llvm.const_int (Llvm.i64_type ctx) i in
-            let slot = Llvm.build_gep f64 ep [| idx |] ("es_" ^ name) builder in
-            let cap  = StringMap.find name env in
-            ignore (Llvm.build_store cap slot builder))
-          fv;
+          List.iteri (fun i (name, _) ->
+            let cap      = StringMap.find name env in
+            let slot_ty  = Llvm.type_of cap in
+            let byte_off = Llvm.const_int (Llvm.i64_type ctx) (i * 8) in
+            let slot     = Llvm.build_gep i8 ep [| byte_off |] ("es_" ^ name) builder in
+            ignore (Llvm.build_store cap slot builder);
+            ignore slot_ty)  (* slot_ty used via cap *)
+          fv_caps;
           ep
         end
       in
-      build_closure ctx builder lam_fn env_ptr
+      build_closure ctx md builder lam_fn env_ptr
 
   | App (e_fn, e_arg) ->
       let f64 = Llvm.double_type ctx in
@@ -449,16 +501,29 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
                 end else begin
                   let fv = compile_expr ctx md builder known_fns env false e_fn in
                   let av = compile_expr ctx md builder known_fns env false e_arg in
-                  call_closure ctx builder fv av
+                  call_closure ctx builder fv av f64
                 end
             | None ->
-                let fv = compile_expr ctx md builder known_fns env false e_fn in
-                let av = compile_expr ctx md builder known_fns env false e_arg in
-                call_closure ctx builder fv av)
+                (* Unresolved name: simulate curried closure application over all args.
+                   Non-final calls return ptr (intermediate closure); final returns f64. *)
+                let fv = compile_expr ctx md builder known_fns env false (Var name) in
+                let vargs = List.map (compile_expr ctx md builder known_fns env false) args in
+                let n = List.length vargs in
+                snd (List.fold_left (fun (i, clos) av ->
+                  let ret_ty = if i = n - 1 then f64 else p in
+                  (i + 1, call_closure ctx builder clos av ret_ty)
+                ) (0, fv) vargs))
        | None ->
+           (* Non-variable function position: determine return type from e_fn shape *)
            let fv = compile_expr ctx md builder known_fns env false e_fn in
            let av = compile_expr ctx md builder known_fns env false e_arg in
-           call_closure ctx builder fv av)
+           let ret_ty = match e_fn with
+             | Lam (_, lbody) ->
+                 if body_returns_list StringSet.empty lbody then p else f64
+             | App _ -> p  (* intermediate curried call returns a closure *)
+             | _ -> f64
+           in
+           call_closure ctx builder fv av ret_ty)
 
   | List items ->
       let p = ptr_ty ctx in
@@ -673,10 +738,11 @@ let compile_module exprs =
       (Hashtbl.replace list_arg_tbl (fn, i) true; true)
     else false
   in
-  (* Seed: arg directly matched with cons/nil *)
+  (* Seed: arg directly matched with cons/nil, or used in function-call position (closure) *)
   List.iter (fun (name, args, body) ->
     List.iteri (fun i a ->
-      if arg_is_list_in_body a body then ignore (mark name i)) args
+      if arg_is_list_in_body a body || arg_is_closure_in_body a body
+      then ignore (mark name i)) args
   ) fundefs;
   (* Seed: arg appears as cons tail — cons _ arg *)
   List.iter (fun (name, args, body) ->

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -706,6 +706,9 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
       in
       Llvm.build_call ft fn (Array.of_list vargs) "r" builder
 
+  | Dict _ -> failwith "codegen: Dict literals not yet supported in native compile (requires polymorphic value representation)"
+  | Try  _ -> failwith "codegen: try/catch not yet supported in native compile"
+  | Import _ -> Llvm.const_float (Llvm.double_type ctx) 0.0  (* resolved before codegen *)
   | e -> failwith ("codegen: unsupported expression: " ^ string_of_expr e)
 
 (* Compile a named function body into its pre-declared (or freshly declared) LLVM function.

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -47,6 +47,7 @@ let inline_primitives = StringSet.of_list [
   "length"; "concat"; "substring"; "uppercase"; "lowercase"; "trim";
   "contains"; "startsWith"; "endsWith"; "replace"; "toFloat";
   "indexOf"; "charAt";
+  "get"; "set"; "has";
 ]
 
 (* Variables bound by a pattern *)
@@ -241,6 +242,14 @@ let declare_ext md name ft =
   | Some f -> f
   | None -> Llvm.declare_function name ft md
 
+(* Auto-unbox a dict value: if v is ptr (boxed f64), load the double.
+   Used in arithmetic operators so dict-get results work transparently. *)
+let auto_unbox_f64 ctx builder v =
+  match Llvm.classify_type (Llvm.type_of v) with
+  | Llvm.TypeKind.Pointer ->
+      Llvm.build_load (Llvm.double_type ctx) v "unbox" builder
+  | _ -> v
+
 (* ── Main expression compiler ───────────────────────────────────────────────── *)
 (* known_fns: name → (function_type, function_value)
    Storing ft explicitly avoids relying on Llvm.type_of which may return ptr in LLVM 18.
@@ -365,22 +374,22 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
            let null_ptr = Llvm.const_null p in
            let cond = Llvm.build_icmp Llvm.Icmp.Eq lst null_ptr "is_empty" builder in
            Llvm.build_uitofp cond f64 "emptyf" builder
-       (* ── Comparison ops ── *)
+       (* ── Comparison ops (auto-unbox boxed f64 from dict get) ── *)
        | Some ("gt",  [a; b]) ->
-           let av = compile_expr ctx md builder known_fns env false a in
-           let bv = compile_expr ctx md builder known_fns env false b in
+           let av = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false a) in
+           let bv = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false b) in
            Llvm.build_uitofp (Llvm.build_fcmp Llvm.Fcmp.Ogt av bv "gt" builder) f64 "gtf" builder
        | Some ("lt",  [a; b]) ->
-           let av = compile_expr ctx md builder known_fns env false a in
-           let bv = compile_expr ctx md builder known_fns env false b in
+           let av = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false a) in
+           let bv = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false b) in
            Llvm.build_uitofp (Llvm.build_fcmp Llvm.Fcmp.Olt av bv "lt" builder) f64 "ltf" builder
        | Some ("gte", [a; b]) ->
-           let av = compile_expr ctx md builder known_fns env false a in
-           let bv = compile_expr ctx md builder known_fns env false b in
+           let av = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false a) in
+           let bv = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false b) in
            Llvm.build_uitofp (Llvm.build_fcmp Llvm.Fcmp.Oge av bv "gte" builder) f64 "gtef" builder
        | Some ("lte", [a; b]) ->
-           let av = compile_expr ctx md builder known_fns env false a in
-           let bv = compile_expr ctx md builder known_fns env false b in
+           let av = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false a) in
+           let bv = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false b) in
            Llvm.build_uitofp (Llvm.build_fcmp Llvm.Fcmp.Ole av bv "lte" builder) f64 "ltef" builder
        | Some ("not", [x]) ->
            let xv = compile_expr ctx md builder known_fns env false x in
@@ -491,6 +500,34 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
            let p = ptr_ty ctx in
            let ft = Llvm.function_type f64 [| p |] in
            Llvm.build_call ft (declare_ext md "churing_to_float" ft) [| sv |] "tofloat" builder
+       (* ── Dict operations ── *)
+       | Some ("get", [dict_e; key_e]) ->
+           let dv = compile_expr ctx md builder known_fns env false dict_e in
+           let kv = compile_expr ctx md builder known_fns env false key_e in
+           let p = ptr_ty ctx in
+           let ft = Llvm.function_type p [| p; p |] in
+           Llvm.build_call ft (declare_ext md "churing_dict_get" ft) [| dv; kv |] "dget" builder
+       | Some ("set", [dict_e; key_e; val_e]) ->
+           let dv  = compile_expr ctx md builder known_fns env false dict_e in
+           let kv  = compile_expr ctx md builder known_fns env false key_e in
+           let raw = compile_expr ctx md builder known_fns env false val_e in
+           let p   = ptr_ty ctx in
+           let f64 = Llvm.double_type ctx in
+           let box_ft = Llvm.function_type p [| f64 |] in
+           let val_v =
+             match Llvm.classify_type (Llvm.type_of raw) with
+             | Llvm.TypeKind.Double ->
+                 Llvm.build_call box_ft (declare_ext md "churing_box_f64" box_ft) [| raw |] "boxed" builder
+             | _ -> raw
+           in
+           let set_ft = Llvm.function_type p [| p; p; p |] in
+           Llvm.build_call set_ft (declare_ext md "churing_dict_set" set_ft) [| dv; kv; val_v |] "dset" builder
+       | Some ("has", [dict_e; key_e]) ->
+           let dv = compile_expr ctx md builder known_fns env false dict_e in
+           let kv = compile_expr ctx md builder known_fns env false key_e in
+           let p = ptr_ty ctx in
+           let ft = Llvm.function_type f64 [| p; p |] in
+           Llvm.build_call ft (declare_ext md "churing_dict_has" ft) [| dv; kv |] "dhas" builder
        | Some ("indexOf", [s_expr; sub_expr]) ->
            let sv  = compile_expr ctx md builder known_fns env false s_expr in
            let sub = compile_expr ctx md builder known_fns env false sub_expr in
@@ -659,41 +696,47 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
       compile_expr ctx md builder known_fns env in_tail ve
 
   | Add (a, b) ->
-      Llvm.build_fadd
-        (compile_expr ctx md builder known_fns env false a)
-        (compile_expr ctx md builder known_fns env false b)
-        "add" builder
+      let av = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false a) in
+      let bv = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false b) in
+      Llvm.build_fadd av bv "add" builder
   | Sub (a, b) ->
-      Llvm.build_fsub
-        (compile_expr ctx md builder known_fns env false a)
-        (compile_expr ctx md builder known_fns env false b)
-        "sub" builder
+      let av = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false a) in
+      let bv = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false b) in
+      Llvm.build_fsub av bv "sub" builder
   | Mul (a, b) ->
-      Llvm.build_fmul
-        (compile_expr ctx md builder known_fns env false a)
-        (compile_expr ctx md builder known_fns env false b)
-        "mul" builder
+      let av = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false a) in
+      let bv = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false b) in
+      Llvm.build_fmul av bv "mul" builder
   | Div (a, b) ->
-      Llvm.build_fdiv
-        (compile_expr ctx md builder known_fns env false a)
-        (compile_expr ctx md builder known_fns env false b)
-        "div" builder
+      let av = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false a) in
+      let bv = auto_unbox_f64 ctx builder (compile_expr ctx md builder known_fns env false b) in
+      Llvm.build_fdiv av bv "div" builder
   | Eq (a, b) ->
       let f64 = Llvm.double_type ctx in
       let p = ptr_ty ctx in
       let av = compile_expr ctx md builder known_fns env false a in
       let bv = compile_expr ctx md builder known_fns env false b in
-      (match Llvm.classify_type (Llvm.type_of av) with
-       | Llvm.TypeKind.Pointer ->
+      (* Mixed ptr/f64: one is a boxed double from a dict get, unbox before comparing *)
+      let av_is_ptr = Llvm.classify_type (Llvm.type_of av) = Llvm.TypeKind.Pointer in
+      let bv_is_ptr = Llvm.classify_type (Llvm.type_of bv) = Llvm.TypeKind.Pointer in
+      (match av_is_ptr, bv_is_ptr with
+       | true, true ->
+           (* Both ptr: string comparison *)
            let strcmp_ft = Llvm.function_type (Llvm.i32_type ctx) [| p; p |] in
            let strcmp_fn = declare_ext md "strcmp" strcmp_ft in
            let cmp = Llvm.build_call strcmp_ft strcmp_fn [| av; bv |] "scmp" builder in
            let z = Llvm.const_int (Llvm.i32_type ctx) 0 in
            Llvm.build_uitofp (Llvm.build_icmp Llvm.Icmp.Eq cmp z "seq" builder) f64 "seqf" builder
-       | _ ->
-           Llvm.build_uitofp
-             (Llvm.build_fcmp Llvm.Fcmp.Oeq av bv "eq" builder)
-             f64 "eqf" builder)
+       | true, false ->
+           (* av is boxed double, bv is f64 *)
+           let av_f = Llvm.build_load f64 av "unbox" builder in
+           Llvm.build_uitofp (Llvm.build_fcmp Llvm.Fcmp.Oeq av_f bv "eq" builder) f64 "eqf" builder
+       | false, true ->
+           (* av is f64, bv is boxed double *)
+           let bv_f = Llvm.build_load f64 bv "unbox" builder in
+           Llvm.build_uitofp (Llvm.build_fcmp Llvm.Fcmp.Oeq av bv_f "eq" builder) f64 "eqf" builder
+       | false, false ->
+           Llvm.build_uitofp (Llvm.build_fcmp Llvm.Fcmp.Oeq av bv "eq" builder) f64 "eqf" builder)
 
   | Llvm (intrinsic, args) ->
       let f64 = Llvm.double_type ctx in
@@ -706,7 +749,27 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
       in
       Llvm.build_call ft fn (Array.of_list vargs) "r" builder
 
-  | Dict _ -> failwith "codegen: Dict literals not yet supported in native compile (requires polymorphic value representation)"
+  | Dict entries ->
+      (* Alist: each entry = 24-byte node {key_ptr, value_ptr, next_ptr}.
+         f64 values are boxed via churing_box_f64 so all values are stored as ptr. *)
+      let p = ptr_ty ctx in
+      let f64 = Llvm.double_type ctx in
+      let set_ft = Llvm.function_type p [| p; p; p |] in
+      let set_fn = declare_ext md "churing_dict_set" set_ft in
+      let box_ft = Llvm.function_type p [| f64 |] in
+      let box_fn = declare_ext md "churing_box_f64" box_ft in
+      let null_p = Llvm.const_null p in
+      List.fold_left (fun acc_dict (key_str, val_e) ->
+        let key_v = compile_expr ctx md builder known_fns env false (Str key_str) in
+        let raw   = compile_expr ctx md builder known_fns env false val_e in
+        let val_v =
+          match Llvm.classify_type (Llvm.type_of raw) with
+          | Llvm.TypeKind.Double ->
+              Llvm.build_call box_ft box_fn [| raw |] "boxed" builder
+          | _ -> raw
+        in
+        Llvm.build_call set_ft set_fn [| acc_dict; key_v; val_v |] "dict" builder
+      ) null_p entries
   | Try  _ -> failwith "codegen: try/catch not yet supported in native compile"
   | Import _ -> Llvm.const_float (Llvm.double_type ctx) 0.0  (* resolved before codegen *)
   | e -> failwith ("codegen: unsupported expression: " ^ string_of_expr e)

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -52,6 +52,7 @@ let inline_primitives = StringSet.of_list [
   "matchList"; "matchBool";
   "env"; "envOr";
   "toString"; "str";
+  "readFile"; "writeFile"; "appendFile"; "fileExists"; "deleteFile";
 ]
 
 (* Variables bound by a pattern *)
@@ -460,6 +461,34 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
            let p = ptr_ty ctx in
            let ft = Llvm.function_type p [| p; p |] in
            Llvm.build_call ft (declare_ext md "churing_env_or" ft) [| nv; dv |] "envOr" builder
+       (* ── File I/O ── *)
+       | Some ("readFile", [path_e]) ->
+           let pv = compile_expr ctx md builder known_fns env false path_e in
+           let p = ptr_ty ctx in
+           let ft = Llvm.function_type p [| p |] in
+           Llvm.build_call ft (declare_ext md "churing_read_file" ft) [| pv |] "rfile" builder
+       | Some ("writeFile", [path_e; content_e]) ->
+           let pv = compile_expr ctx md builder known_fns env false path_e in
+           let cv = compile_expr ctx md builder known_fns env false content_e in
+           let p = ptr_ty ctx in
+           let ft = Llvm.function_type f64 [| p; p |] in
+           Llvm.build_call ft (declare_ext md "churing_write_file" ft) [| pv; cv |] "wfile" builder
+       | Some ("appendFile", [path_e; content_e]) ->
+           let pv = compile_expr ctx md builder known_fns env false path_e in
+           let cv = compile_expr ctx md builder known_fns env false content_e in
+           let p = ptr_ty ctx in
+           let ft = Llvm.function_type f64 [| p; p |] in
+           Llvm.build_call ft (declare_ext md "churing_append_file" ft) [| pv; cv |] "afile" builder
+       | Some ("fileExists", [path_e]) ->
+           let pv = compile_expr ctx md builder known_fns env false path_e in
+           let p = ptr_ty ctx in
+           let ft = Llvm.function_type f64 [| p |] in
+           Llvm.build_call ft (declare_ext md "churing_file_exists" ft) [| pv |] "fexists" builder
+       | Some ("deleteFile", [path_e]) ->
+           let pv = compile_expr ctx md builder known_fns env false path_e in
+           let p = ptr_ty ctx in
+           let ft = Llvm.function_type f64 [| p |] in
+           Llvm.build_call ft (declare_ext md "churing_delete_file" ft) [| pv |] "delfile" builder
        (* ── String operations ── *)
        | Some ("length", [s_expr]) ->
            let sv = compile_expr ctx md builder known_fns env false s_expr in
@@ -776,16 +805,12 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
        | [] -> failwith "codegen: match with no reachable arms"
        | results -> Llvm.build_phi results "match_r" builder)
 
-  | Seq (Let (name, ve), rest) ->
-      let v = compile_expr ctx md builder known_fns env false ve in
-      compile_expr ctx md builder known_fns (StringMap.add name v env) in_tail rest
-  | Seq (FunDef (name, args, body), rest) ->
-      (* Nested function definition — compile it and add to known_fns for the rest *)
-      ignore (compile_fundef ctx md known_fns name args body);
-      compile_expr ctx md builder known_fns env in_tail rest
+  (* Seq: parse_seq builds left-folded trees Seq(Seq(Seq(e1,e2),e3),e4).
+     Flatten via compile_seq_for_env so Let/FunDef bindings thread through env
+     regardless of whether the tree is left- or right-nested. *)
   | Seq (a, b) ->
-      ignore (compile_expr ctx md builder known_fns env false a);
-      compile_expr ctx md builder known_fns env in_tail b
+      let env' = compile_seq_for_env ctx md builder known_fns env a in
+      compile_expr ctx md builder known_fns env' in_tail b
   | Let (_, ve) ->
       compile_expr ctx md builder known_fns env in_tail ve
 
@@ -867,6 +892,22 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
   | Try  _ -> failwith "codegen: try/catch not yet supported in native compile"
   | Import _ -> Llvm.const_float (Llvm.double_type ctx) 0.0  (* resolved before codegen *)
   | e -> failwith ("codegen: unsupported expression: " ^ string_of_expr e)
+
+(* Process a sub-expression for its side effects and Let/FunDef bindings.
+   Returns updated env. Used by the Seq case to handle left-folded parse trees. *)
+and compile_seq_for_env ctx md builder known_fns env = function
+  | Let (name, ve) ->
+      let v = compile_expr ctx md builder known_fns env false ve in
+      StringMap.add name v env
+  | FunDef (name, args, body) ->
+      ignore (compile_fundef ctx md known_fns name args body);
+      env
+  | Seq (a, b) ->
+      let env' = compile_seq_for_env ctx md builder known_fns env a in
+      compile_seq_for_env ctx md builder known_fns env' b
+  | e ->
+      ignore (compile_expr ctx md builder known_fns env false e);
+      env
 
 (* Compile a named function body into its pre-declared (or freshly declared) LLVM function.
    When called from compile_module, the function is already in known_fns (from the pre-pass)

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -46,6 +46,7 @@ let inline_primitives = StringSet.of_list [
   "print";
   "length"; "concat"; "substring"; "uppercase"; "lowercase"; "trim";
   "contains"; "startsWith"; "endsWith"; "replace"; "toFloat";
+  "indexOf"; "charAt";
 ]
 
 (* Variables bound by a pattern *)
@@ -489,6 +490,18 @@ let rec compile_expr ctx md builder (known_fns : (string, Llvm.lltype * Llvm.llv
            let p = ptr_ty ctx in
            let ft = Llvm.function_type f64 [| p |] in
            Llvm.build_call ft (declare_ext md "churing_to_float" ft) [| sv |] "tofloat" builder
+       | Some ("indexOf", [s_expr; sub_expr]) ->
+           let sv  = compile_expr ctx md builder known_fns env false s_expr in
+           let sub = compile_expr ctx md builder known_fns env false sub_expr in
+           let p = ptr_ty ctx in
+           let ft = Llvm.function_type f64 [| p; p |] in
+           Llvm.build_call ft (declare_ext md "churing_index_of" ft) [| sv; sub |] "indexof" builder
+       | Some ("charAt", [s_expr; idx_expr]) ->
+           let sv  = compile_expr ctx md builder known_fns env false s_expr in
+           let iv  = compile_expr ctx md builder known_fns env false idx_expr in
+           let p = ptr_ty ctx in
+           let ft = Llvm.function_type p [| p; f64 |] in
+           Llvm.build_call ft (declare_ext md "churing_char_at" ft) [| sv; iv |] "charat" builder
        (* ── if cond then_val else_val ── *)
        | Some ("if", [cond_e; then_e; else_e]) ->
            let cond_v = compile_expr ctx md builder known_fns env false cond_e in

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -86,7 +86,16 @@ let rec free_vars bound = function
         let bound' = StringSet.union bound (pattern_vars pat) in
         StringSet.union s (free_vars bound' body))
       fv_e arms
-  | _ -> StringSet.empty
+  | Assert e -> free_vars bound e
+  | Dict entries ->
+      List.fold_left (fun s (_, v) -> StringSet.union s (free_vars bound v))
+        StringSet.empty entries
+  | Try (e, h) -> StringSet.union (free_vars bound e) (free_vars bound h)
+  | FunDef (name, args, body) ->
+      let bound' = List.fold_left (fun s a -> StringSet.add a s)
+        (StringSet.add name bound) args in
+      free_vars bound' body
+  | Import _ -> StringSet.empty
 
 (* Flatten App(App(Var f, a1), a2) → Some (f, [a1; a2]) *)
 let rec flatten_app acc = function
@@ -195,9 +204,10 @@ let rec arg_is_list_in_body arg_name = function
       List.exists (fun (_, b) -> arg_is_list_in_body arg_name b) arms
   | Seq (a, b) -> arg_is_list_in_body arg_name a || arg_is_list_in_body arg_name b
   | App _ as full_app ->
-      (* matchList arg ... ⟹ arg is a list *)
+      (* matchList arg ... ⟹ arg is a list; get/has/set arg "k" ⟹ arg is a dict (ptr) *)
       (match flatten_app [] full_app with
        | Some ("matchList", Var x :: _) when x = arg_name -> true
+       | Some (("get" | "has" | "set" | "remove"), Var x :: _) when x = arg_name -> true
        | Some (_, args) ->
            List.exists (arg_is_list_in_body arg_name) args
        | None ->
@@ -234,6 +244,7 @@ let rec cons_tail_vars = function
    is_list_arg: test if a var name is a list-typed argument. *)
 let rec body_returns_list_v list_fns list_vars is_list_arg = function
   | List _ -> true
+  | Dict _ -> true  (* dict literals are heap-allocated ptr *)
   | Lam _ -> true  (* lambdas are heap-allocated — return ptr *)
   | Var x -> StringSet.mem x list_vars || StringSet.mem x list_fns || is_list_arg x
   | Match (_, arms) ->
@@ -241,10 +252,12 @@ let rec body_returns_list_v list_fns list_vars is_list_arg = function
         let extra = cons_tail_vars pat in
         body_returns_list_v list_fns (StringSet.union list_vars extra) is_list_arg body) arms
   | Seq (_, b) -> body_returns_list_v list_fns list_vars is_list_arg b
+  | Let (_, v) -> body_returns_list_v list_fns list_vars is_list_arg v
   | App (f, _) ->
       (match flatten_app [] f with
        | Some ("cons", _) -> true
        | Some ("matchList", _) -> true
+       | Some (("get" | "set"), _) -> true  (* dict get/set returns ptr *)
        | Some (name, _) -> StringSet.mem name list_fns
        | None -> false)
   | _ -> false
@@ -1140,14 +1153,45 @@ let compile_to_binary ?(output="a.out") exprs =
     load_stdlib_fundefs "math.ch"       @
     load_stdlib_fundefs "prelude.ch"    @
     load_stdlib_fundefs "operators.ch"  @
-    load_stdlib_fundefs "list.ch"       @
+    (* list.ch skipped: prelude.ch covers sum/product/append/take/drop/any/all;
+       zip/flatten need polymorphic cons cells (Task #22) *)
     load_stdlib_fundefs "vector.ch"     @
     load_stdlib_fundefs "matrix.ch"     @
     load_stdlib_fundefs "activations.ch" @
     load_stdlib_fundefs "loss.ch"       @
     load_stdlib_fundefs "nn.ch"
   in
-  let all_exprs = stdlib @ exprs in
+  (* Tree-shake: only compile stdlib functions the program transitively uses.
+     The full ML stdlib (vector/matrix/nn) currently emits invalid IR for some
+     functions (#117); force-loading all of it broke every compile (#110), even
+     trivial programs. Reachability over free_vars keeps unused (and currently
+     broken) functions out of the module entirely. Functions referenced that are
+     runtime primitives rather than FunDefs are simply ignored here — they are
+     declared on demand during codegen. *)
+  let stdlib_tbl : (string, string list * expr) Hashtbl.t = Hashtbl.create 64 in
+  List.iter (function
+    | FunDef (n, args, body) ->
+        if not (Hashtbl.mem stdlib_tbl n) then Hashtbl.add stdlib_tbl n (args, body)
+    | _ -> ()) stdlib;
+  let reachable = ref StringSet.empty in
+  let worklist = ref [] in
+  let add_name n =
+    if Hashtbl.mem stdlib_tbl n && not (StringSet.mem n !reachable) then begin
+      reachable := StringSet.add n !reachable;
+      worklist := n :: !worklist
+    end in
+  List.iter (fun e -> StringSet.iter add_name (free_vars StringSet.empty e)) exprs;
+  while !worklist <> [] do
+    let n = List.hd !worklist in
+    worklist := List.tl !worklist;
+    let (args, body) = Hashtbl.find stdlib_tbl n in
+    let bound = List.fold_left (fun s a -> StringSet.add a s) StringSet.empty args in
+    StringSet.iter add_name (free_vars bound body)
+  done;
+  let stdlib_used = List.filter (function
+    | FunDef (n, _, _) -> StringSet.mem n !reachable
+    | _ -> false) stdlib in
+  let all_exprs = stdlib_used @ exprs in
   let (ctx, md, known_fns) = compile_module all_exprs in
   let non_fundefs = List.filter (function FunDef _ -> false | _ -> true) exprs in
   if non_fundefs <> [] then

--- a/src/lib/loss.ch
+++ b/src/lib/loss.ch
@@ -1,12 +1,12 @@
 # Loss functions for neural network
 
+# One-hot encode helper: lifted to top level for native compile
+~oneHotBuild label,size,i (match (eq i size)
+    | true -> []
+    | false -> cons (matchBool (eq i label) 1.0 0.0) (oneHotBuild label size (i + 1)))
+
 # One-hot encode: label -> size -> vector with 1.0 at label index
-~oneHot label,size (
-    ~build i (match (eq i size)
-        | true -> []
-        | false -> cons (matchBool (eq i label) 1.0 0.0) (build (i + 1)))
-    build 0
-)
+~oneHot label,size (oneHotBuild label size 0)
 
 # Cross-entropy loss: -log(predicted[label])
 # predicted is a probability vector (output of softmax), label is the correct class index

--- a/src/lib/prelude.ch
+++ b/src/lib/prelude.ch
@@ -1,7 +1,5 @@
 # Prelude — pure Churing list helpers for the native compile pipeline.
 # Interpreter ignores this file (OCaml VPrim versions take precedence).
-# Higher-order functions (map, filter, foldl) require closure-typed
-# parameters and are not yet supported in the LLVM backend.
 
 ~len xs (match xs | [] -> 0.0 | _ :: t -> 1.0 + len t)
 ~sum xs (match xs | [] -> 0.0 | h :: t -> h + sum t)
@@ -13,3 +11,10 @@
 ~drop n,xs (match xs | [] -> [] | _ :: t -> match (eq n 0.0) | true -> xs | _ -> drop (n - 1.0) t)
 ~nth n,xs (match xs | h :: t -> match (eq n 0.0) | true -> h | _ -> nth (n - 1.0) t)
 ~range lo,hi (match (gte lo hi) | true -> [] | _ -> cons lo (range (lo + 1.0) hi))
+
+~map f,xs (match xs | [] -> [] | h :: t -> cons (f h) (map f t))
+~filter pred,xs (match xs | [] -> [] | h :: t -> match (pred h) | true -> cons h (filter pred t) | _ -> filter pred t)
+~foldl f,acc,xs (match xs | [] -> acc | h :: t -> foldl f (f acc h) t)
+~foldr f,acc,xs (match xs | [] -> acc | h :: t -> f h (foldr f acc t))
+~any pred,xs (match xs | [] -> false | h :: t -> match (pred h) | true -> true | _ -> any pred t)
+~all pred,xs (match xs | [] -> true | h :: t -> match (pred h) | true -> all pred t | _ -> false)

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -263,6 +263,11 @@ and parse_var_def tokens =
   | (At, line, col) :: (Ident name, _, _) :: rest ->
       let value, rest' = parse_add rest in
       (Let (name, value), rest')
+  | (At, _, _) :: (Underscore, _, _) :: rest ->
+      (* @_ value — discard binding (run for side effects). Without this case the
+         leading @ token is never consumed and the top-level loop recurses forever. *)
+      let value, rest' = parse_add rest in
+      (Let ("_", value), rest')
   | _ -> parse_add tokens
 
 and parse_add tokens =

--- a/src/rust/native/src/runtime.rs
+++ b/src/rust/native/src/runtime.rs
@@ -195,3 +195,46 @@ pub unsafe extern "C" fn churing_env_or(name: *const i8, default: *const i8) -> 
         Err(_) => default,
     }
 }
+
+// ── File I/O ─────────────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_read_file(path: *const i8) -> *const i8 {
+    match std::fs::read_to_string(cstr(path)) {
+        Ok(s) => alloc_str(&s),
+        Err(e) => {
+            eprintln!("readFile: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_write_file(path: *const i8, content: *const i8) -> f64 {
+    match std::fs::write(cstr(path), cstr(content).as_bytes()) {
+        Ok(_) => 1.0,
+        Err(e) => { eprintln!("writeFile: {}", e); std::process::exit(1); }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_append_file(path: *const i8, content: *const i8) -> f64 {
+    use std::io::Write;
+    match std::fs::OpenOptions::new().append(true).create(true).open(cstr(path)) {
+        Ok(mut f) => { let _ = f.write_all(cstr(content).as_bytes()); 1.0 }
+        Err(e) => { eprintln!("appendFile: {}", e); std::process::exit(1); }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_file_exists(path: *const i8) -> f64 {
+    if std::path::Path::new(cstr(path)).exists() { 1.0 } else { 0.0 }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_delete_file(path: *const i8) -> f64 {
+    match std::fs::remove_file(cstr(path)) {
+        Ok(_) => 1.0,
+        Err(e) => { eprintln!("deleteFile: {}", e); std::process::exit(1); }
+    }
+}

--- a/src/rust/native/src/runtime.rs
+++ b/src/rust/native/src/runtime.rs
@@ -87,6 +87,27 @@ pub unsafe extern "C" fn churing_to_float(s: *const i8) -> f64 {
     cstr(s).parse::<f64>().unwrap_or(0.0)
 }
 
+// ── Random number (LCG) ─────────────────────────────────────────────────────
+use std::cell::Cell;
+thread_local! {
+    static LCG: Cell<u64> = Cell::new(6364136223846793005u64);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_random(_dummy: f64) -> f64 {
+    LCG.with(|s| {
+        let v = s.get().wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        s.set(v);
+        (v >> 11) as f64 / (1u64 << 53) as f64
+    })
+}
+
+// ── toInt / str ──────────────────────────────────────────────────────────────
+#[no_mangle]
+pub unsafe extern "C" fn churing_to_int(n: f64) -> f64 {
+    n.trunc()
+}
+
 // ── Dict (association list) ──────────────────────────────────────────────────
 // Each node: { key_ptr:8, value_ptr:8, next_ptr:8 } = 24 bytes
 // Values are always stored as ptr. f64 values are boxed via GC_malloc(8).
@@ -151,5 +172,26 @@ pub unsafe extern "C" fn churing_char_at(s: *const i8, idx: f64) -> *const i8 {
         alloc_str(std::str::from_utf8_unchecked(&bytes[i..i + 1]))
     } else {
         alloc_str("")
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_env(name: *const i8) -> *const i8 {
+    let key = cstr(name);
+    match std::env::var(key) {
+        Ok(v) => alloc_str(&v),
+        Err(_) => {
+            eprintln!("env: variable not set: {}", key);
+            std::process::exit(1);
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_env_or(name: *const i8, default: *const i8) -> *const i8 {
+    let key = cstr(name);
+    match std::env::var(key) {
+        Ok(v) => alloc_str(&v),
+        Err(_) => default,
     }
 }

--- a/src/rust/native/src/runtime.rs
+++ b/src/rust/native/src/runtime.rs
@@ -86,3 +86,22 @@ pub unsafe extern "C" fn churing_to_string(n: f64) -> *const i8 {
 pub unsafe extern "C" fn churing_to_float(s: *const i8) -> f64 {
     cstr(s).parse::<f64>().unwrap_or(0.0)
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_index_of(s: *const i8, sub: *const i8) -> f64 {
+    match cstr(s).find(cstr(sub)) {
+        Some(idx) => idx as f64,
+        None => -1.0,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_char_at(s: *const i8, idx: f64) -> *const i8 {
+    let bytes = cstr(s).as_bytes();
+    let i = idx as usize;
+    if i < bytes.len() {
+        alloc_str(std::str::from_utf8_unchecked(&bytes[i..i + 1]))
+    } else {
+        alloc_str("")
+    }
+}

--- a/src/rust/native/src/runtime.rs
+++ b/src/rust/native/src/runtime.rs
@@ -87,6 +87,54 @@ pub unsafe extern "C" fn churing_to_float(s: *const i8) -> f64 {
     cstr(s).parse::<f64>().unwrap_or(0.0)
 }
 
+// ── Dict (association list) ──────────────────────────────────────────────────
+// Each node: { key_ptr:8, value_ptr:8, next_ptr:8 } = 24 bytes
+// Values are always stored as ptr. f64 values are boxed via GC_malloc(8).
+// Null ptr = empty dict.
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_dict_set(dict: *mut u8, key: *const i8, val: *const u8) -> *mut u8 {
+    let node = GC_malloc(24);
+    *(node as *mut *const i8) = key;
+    *(node.add(8) as *mut *const u8) = val;
+    *(node.add(16) as *mut *mut u8) = dict;
+    node
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_dict_get(dict: *mut u8, key: *const i8) -> *const u8 {
+    let key_str = cstr(key);
+    let mut cur = dict;
+    while !cur.is_null() {
+        let node_key = cstr(*(cur as *const *const i8));
+        if node_key == key_str {
+            return *(cur.add(8) as *const *const u8);
+        }
+        cur = *(cur.add(16) as *const *mut u8);
+    }
+    std::ptr::null()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn churing_dict_has(dict: *mut u8, key: *const i8) -> f64 {
+    let key_str = cstr(key);
+    let mut cur = dict;
+    while !cur.is_null() {
+        let node_key = cstr(*(cur as *const *const i8));
+        if node_key == key_str { return 1.0; }
+        cur = *(cur.add(16) as *const *mut u8);
+    }
+    0.0
+}
+
+// Box a f64 so it can be stored as a dict value (ptr)
+#[no_mangle]
+pub unsafe extern "C" fn churing_box_f64(val: f64) -> *const u8 {
+    let p = GC_malloc(8);
+    *(p as *mut f64) = val;
+    p
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn churing_index_of(s: *const i8, sub: *const i8) -> f64 {
     match cstr(s).find(cstr(sub)) {

--- a/src/test/52_native_hof.ch
+++ b/src/test/52_native_hof.ch
@@ -1,0 +1,24 @@
+# Test: polymorphic lambdas and HOF in native compile pipeline
+# Uses interpreter-compatible API (nth list int, sum, len)
+
+@doubled (map (|>x. x * 2.0) [1.0, 2.0, 3.0])
+assert (eq (sum doubled) 12.0)
+assert (eq (len doubled) 3.0)
+assert (eq (head doubled) 2.0)
+
+@evens (filter (|>x. gt x 2.0) [1.0, 2.0, 3.0, 4.0, 5.0])
+assert (eq (len evens) 3.0)
+assert (eq (sum evens) 12.0)
+assert (eq (head evens) 3.0)
+
+@total (foldl (|>acc. |>x. acc + x) 0.0 [1.0, 2.0, 3.0, 4.0])
+assert (eq total 10.0)
+
+@squares (map (|>x. x * x) [1.0, 2.0, 3.0, 4.0, 5.0])
+assert (eq (sum squares) 55.0)
+
+# Lambda capturing a variable
+@scale 3.0
+@scaled (map (|>x. x * scale) [1.0, 2.0, 3.0])
+assert (eq (sum scaled) 18.0)
+assert (eq (head scaled) 3.0)

--- a/src/test/53_native_if.ch
+++ b/src/test/53_native_if.ch
@@ -1,0 +1,16 @@
+# Test: if primitive in native compile pipeline
+
+@x 5.0
+@y (if (gt x 3.0) 10.0 0.0)
+assert (eq y 10.0)
+
+@z (if (lt x 3.0) 10.0 99.0)
+assert (eq z 99.0)
+
+# Nested if
+@w (if true (if false 1.0 2.0) 3.0)
+assert (eq w 2.0)
+
+# if as expression in arithmetic
+@r (if (eq x 5.0) 100.0 0.0)
+assert (eq r 100.0)

--- a/src/test/54_native_string.ch
+++ b/src/test/54_native_string.ch
@@ -1,0 +1,11 @@
+# Test: string ops in native compile pipeline
+
+@s "hello world"
+
+assert (eq (indexOf s "world") 6.0)
+assert (eq (indexOf s "xyz") (0.0 - 1.0))
+assert (eq (indexOf s "hello") 0.0)
+
+assert (eq (charAt s 0) "h")
+assert (eq (charAt s 4) "o")
+assert (eq (charAt s 6) "w")

--- a/src/test/55_native_lng.ch
+++ b/src/test/55_native_lng.ch
@@ -1,0 +1,6 @@
+# Test: Lng (Int64) literals in native compile pipeline
+@x 1000000000L
+assert (eq x 1000000000.0)
+
+@y 42L
+assert (eq y 42.0)

--- a/src/test/56_native_dict.ch
+++ b/src/test/56_native_dict.ch
@@ -1,0 +1,21 @@
+# Test: Dict support in native compile pipeline
+
+# Basic dict creation and get
+@d {x: 1.0, y: 2.0, z: 3.0}
+assert (eq (get d "x") 1.0)
+assert (eq (get d "y") 2.0)
+assert (eq (get d "z") 3.0)
+
+# Dict with arithmetic on values
+@sum ((get d "x") + (get d "y") + (get d "z"))
+assert (eq sum 6.0)
+
+# Dict with list values
+@items [10.0, 20.0, 30.0]
+@d2 {nums: items, count: 3.0}
+assert (eq (head (get d2 "nums")) 10.0)
+assert (eq (get d2 "count") 3.0)
+
+# has
+assert (has d "x")
+assert (not (has d "w"))

--- a/src/test/57_native_ml_stdlib.ch
+++ b/src/test/57_native_ml_stdlib.ch
@@ -1,0 +1,37 @@
+# Test: matchList, matchBool, vector ops in native compile
+
+# matchBool
+assert (eq (matchBool true 1.0 0.0) 1.0)
+assert (eq (matchBool false 1.0 0.0) 0.0)
+
+# matchList
+@xs [1.0, 2.0, 3.0]
+@result (matchList xs (|>_. 0.0) (|>h. |>t. h))
+assert (eq result 1.0)
+
+@result2 (matchList [] (|>_. 99.0) (|>h. |>t. h))
+assert (eq result2 99.0)
+
+# vecAdd
+@a [1.0, 2.0, 3.0]
+@b [4.0, 5.0, 6.0]
+@c (vecAdd a b)
+assert (eq (head c) 5.0)
+assert (eq (sum c) 21.0)
+
+# vecDot
+assert (eq (vecDot a b) 32.0)
+
+# vecScale
+@scaled (vecScale 2.0 a)
+assert (eq (head scaled) 2.0)
+assert (eq (sum scaled) 12.0)
+
+# vecZeros
+@zeros (vecZeros 3)
+assert (eq (sum zeros) 0.0)
+assert (eq (len zeros) 3.0)
+
+# argmax
+@scores [0.1, 0.8, 0.3, 0.2]
+assert (eq (argmax scores) 1.0)

--- a/src/test/58_native_env_print.ch
+++ b/src/test/58_native_env_print.ch
@@ -1,0 +1,15 @@
+# Test: env, envOr, print strings in native compile
+
+# print a string (uses %s format)
+print "hello from native"
+
+# envOr with missing var returns default
+@host (envOr "NONEXISTENT_VAR_XYZ" "default_host")
+assert (eq host "default_host")
+
+# toString
+@s (toString 42.0)
+assert (eq s "42")
+
+@s2 (toString 3.14)
+assert (eq s2 "3.14")

--- a/src/test/58_native_env_print.ch.out
+++ b/src/test/58_native_env_print.ch.out
@@ -1,0 +1,1 @@
+hello from native

--- a/src/test/59_native_file_io.ch
+++ b/src/test/59_native_file_io.ch
@@ -1,0 +1,22 @@
+# Test: File I/O in native compile pipeline
+
+@content "hello native file io"
+@path "/tmp/churing_test_59.txt"
+
+# write and read back
+@_ (writeFile path content)
+@read_back (readFile path)
+assert (eq read_back content)
+
+# fileExists
+assert (fileExists path)
+assert (not (fileExists "/tmp/churing_nonexistent_xyz.txt"))
+
+# appendFile
+@_ (appendFile path " appended")
+@read2 (readFile path)
+assert (eq read2 "hello native file io appended")
+
+# deleteFile
+@_ (deleteFile path)
+assert (not (fileExists path))

--- a/src/test/60_underscore_binding.ch
+++ b/src/test/60_underscore_binding.ch
@@ -1,0 +1,8 @@
+# Regression: @_ (underscore/discard binding) must not crash the parser.
+# Previously `@_ <expr>` followed by another statement caused a parser
+# stack overflow because the leading @ token was never consumed.
+
+@_ 99.0
+@x 7.0
+@_ (x + 1.0)
+assert (eq x 7.0)


### PR DESCRIPTION
Fixes the native-compile pipeline regression and records the path to full interpreter parity.

## Problem
`compile_to_binary` force-loaded the entire ML stdlib (vector/matrix/activations/loss/nn) into every native module. Several of those functions emit invalid LLVM IR under the current ptr/f64 type pre-pass (#117), so `assert_valid_module` aborted **every** compile — native compile was 0/5, even for a 33-byte print program.

## Fix
- **Tree-shake the stdlib**: only compile stdlib `FunDef`s transitively reachable from the user program, via a reachability fixpoint over `free_vars`. Functions referenced that are runtime primitives (not `FunDef`s) are ignored — declared on demand.
- **Make `free_vars` exhaustive**: it previously returned the empty set for `Assert`/`FunDef`/`Dict`/`Try`/`Import`, which would under-seed reachability (and was a latent under-capture bug in closure conversion).

## Result
- Native compile tests: **0/5 → 5/5** (01_arithmetic, 02_logic, 03_print, 04_stdlib, 05_strings).
- No regression: 31/31 unit tests (incl. 16 codegen) and 50/51 integration tests still pass. The one failure (`59_native_file_io`, stack overflow) is pre-existing and interpreter-only.

## Also
- Adds `docs/native-compile-roadmap.md` — canonical resume doc: current state, ordered Phase 1–4 issue plan, the #117 keystone, and the relevant-vs-deferred issue triage. CLAUDE.md points at it.

## Out of scope (deferred)
- #117 — replace the binary ptr/f64 pre-pass with `infer.ml` HM types + monomorphization (unblocks the ML stack and #106).
- #115 — polymorphic cons cells.